### PR TITLE
fix: resolve NotSupportedException for schema-qualified PostgreSQL enum types

### DIFF
--- a/.github/workflows/legacy-tests.yml
+++ b/.github/workflows/legacy-tests.yml
@@ -71,7 +71,7 @@ jobs:
           shell: pwsh
           command: |
             $mysqlJob = Start-Job -ScriptBlock { 
-              choco install mysql --no-progress --version=8.4.9 -y --params "/serviceName:MySQL" 
+              choco install mysql --no-progress -y --params "/serviceName:MySQL" 
               return $LASTEXITCODE
             }
             

--- a/.github/workflows/legacy-tests.yml
+++ b/.github/workflows/legacy-tests.yml
@@ -71,7 +71,7 @@ jobs:
           shell: pwsh
           command: |
             $mysqlJob = Start-Job -ScriptBlock { 
-              choco install mysql --no-progress --version=8.4.6 -y --params "/serviceName:MySQL" 
+              choco install mysql --no-progress --version=8.4.9 -y --params "/serviceName:MySQL" 
               return $LASTEXITCODE
             }
             

--- a/Drivers/NpgsqlDriver.cs
+++ b/Drivers/NpgsqlDriver.cs
@@ -730,7 +730,7 @@ public sealed class NpgsqlDriver : EnumDbDriver, IOne, IMany, IExec, IExecRows, 
         }).JoinByNewLine();
     }
 
-    private static (string, string) GetEnumSchemaAndName(Column column)
+    private (string, string) GetEnumSchemaAndName(Column column)
     {
         var schemaName = column.Type.Schema;
         var enumName = column.Type.Name;
@@ -740,6 +740,8 @@ public sealed class NpgsqlDriver : EnumDbDriver, IOne, IMany, IExec, IExecRows, 
             schemaName = schemaAndEnum[0];
             enumName = schemaAndEnum[1];
         }
+        if (schemaName == DefaultSchema)
+            schemaName = string.Empty;
         return (schemaName, enumName);
     }
 

--- a/end2end/EndToEndTests/NpgsqlDapperTester.cs
+++ b/end2end/EndToEndTests/NpgsqlDapperTester.cs
@@ -21,6 +21,5 @@ public partial class NpgsqlDapperTester
         await QuerySql.TruncatePostgresNetworkTypesAsync();
         await QuerySql.TruncatePostgresArrayTypesAsync();
         await QuerySql.TruncatePostgresSpecialTypesAsync();
-        await QuerySql.TruncatePostgresQualifiedEnumTypesAsync();
     }
 }

--- a/end2end/EndToEndTests/NpgsqlDapperTester.cs
+++ b/end2end/EndToEndTests/NpgsqlDapperTester.cs
@@ -21,5 +21,6 @@ public partial class NpgsqlDapperTester
         await QuerySql.TruncatePostgresNetworkTypesAsync();
         await QuerySql.TruncatePostgresArrayTypesAsync();
         await QuerySql.TruncatePostgresSpecialTypesAsync();
+        await QuerySql.TruncatePostgresQualifiedEnumTypesAsync();
     }
 }

--- a/end2end/EndToEndTests/NpgsqlTester.cs
+++ b/end2end/EndToEndTests/NpgsqlTester.cs
@@ -22,6 +22,5 @@ public partial class NpgsqlTester
         await QuerySql.TruncatePostgresArrayTypesAsync();
         await QuerySql.TruncatePostgresSpecialTypesAsync();
         await QuerySql.TruncatePostgresNotNullTypesAsync();
-        await QuerySql.TruncatePostgresQualifiedEnumTypesAsync();
     }
 }

--- a/end2end/EndToEndTests/NpgsqlTester.cs
+++ b/end2end/EndToEndTests/NpgsqlTester.cs
@@ -22,5 +22,6 @@ public partial class NpgsqlTester
         await QuerySql.TruncatePostgresArrayTypesAsync();
         await QuerySql.TruncatePostgresSpecialTypesAsync();
         await QuerySql.TruncatePostgresNotNullTypesAsync();
+        await QuerySql.TruncatePostgresQualifiedEnumTypesAsync();
     }
 }

--- a/examples/NpgsqlDapperExample/Models.cs
+++ b/examples/NpgsqlDapperExample/Models.cs
@@ -96,6 +96,10 @@ public class PostgresNotNullType
 {
     public required CEnum CEnumNotNull { get; init; }
 };
+public class PostgresQualifiedEnumType
+{
+    public CEnum? CQualifiedEnum { get; init; }
+};
 public class ExtendedBio
 {
     public required string AuthorName { get; init; }

--- a/examples/NpgsqlDapperExample/Models.cs
+++ b/examples/NpgsqlDapperExample/Models.cs
@@ -85,6 +85,7 @@ public class PostgresSpecialType
 {
     public Guid? CUuid { get; init; }
     public CEnum? CEnum { get; init; }
+    public CEnum? CQualifiedEnum { get; init; }
     public JsonElement? CJson { get; init; }
     public JsonElement? CJsonStringOverride { get; init; }
     public JsonElement? CJsonb { get; init; }
@@ -95,10 +96,6 @@ public class PostgresSpecialType
 public class PostgresNotNullType
 {
     public required CEnum CEnumNotNull { get; init; }
-};
-public class PostgresQualifiedEnumType
-{
-    public CEnum? CQualifiedEnum { get; init; }
 };
 public class ExtendedBio
 {

--- a/examples/NpgsqlDapperExample/QuerySql.cs
+++ b/examples/NpgsqlDapperExample/QuerySql.cs
@@ -1358,7 +1358,8 @@ public class QuerySql : IDisposable
                                                                c_xml,
                                                                c_xml_string_override,
                                                                c_uuid,
-                                                               c_enum
+                                                               c_enum,
+                                                               c_qualified_enum
                                                            )
                                                            VALUES (
                                                                @c_json, 
@@ -1368,7 +1369,8 @@ public class QuerySql : IDisposable
                                                                @c_xml::xml,
                                                                @c_xml_string_override::xml,
                                                                @c_uuid,
-                                                               @c_enum::c_enum
+                                                               @c_enum::c_enum,
+                                                               @c_qualified_enum::c_enum
                                                            )";
     public class InsertPostgresSpecialTypesArgs
     {
@@ -1380,6 +1382,7 @@ public class QuerySql : IDisposable
         public string? CXmlStringOverride { get; init; }
         public Guid? CUuid { get; init; }
         public CEnum? CEnum { get; init; }
+        public CEnum? CQualifiedEnum { get; init; }
     };
     public async Task InsertPostgresSpecialTypesAsync(InsertPostgresSpecialTypesArgs args)
     {
@@ -1392,6 +1395,7 @@ public class QuerySql : IDisposable
         queryParams.Add("c_xml_string_override", args.CXmlStringOverride);
         queryParams.Add("c_uuid", args.CUuid);
         queryParams.Add("c_enum", args.CEnum != null ? args.CEnum.Value.Stringify() : null);
+        queryParams.Add("c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : null);
         if (this.Transaction == null)
         {
             using (var connection = await GetDataSource().OpenConnectionAsync())
@@ -1484,7 +1488,8 @@ public class QuerySql : IDisposable
                                                             c_xml,
                                                             c_xml_string_override,
                                                             c_uuid,
-                                                            c_enum
+                                                            c_enum,
+                                                            c_qualified_enum
                                                         FROM postgres_special_types 
                                                         LIMIT 1";
     public class GetPostgresSpecialTypesRow
@@ -1497,6 +1502,7 @@ public class QuerySql : IDisposable
         public string? CXmlStringOverride { get; init; }
         public Guid? CUuid { get; init; }
         public CEnum? CEnum { get; init; }
+        public CEnum? CQualifiedEnum { get; init; }
     };
     public async Task<GetPostgresSpecialTypesRow?> GetPostgresSpecialTypesAsync()
     {
@@ -1886,75 +1892,5 @@ public class QuerySql : IDisposable
         if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
             throw new InvalidOperationException("Transaction is provided, but its connection is null.");
         await this.Transaction.Connection.ExecuteAsync(TruncatePostgresGeoTypesSql, transaction: this.Transaction);
-    }
-
-    private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
-                                                                 (
-                                                                     c_qualified_enum
-                                                                 )
-                                                                 VALUES (
-                                                                     @c_qualified_enum::c_enum
-                                                                 )";
-    public class InsertPostgresQualifiedEnumTypesArgs
-    {
-        public CEnum? CQualifiedEnum { get; init; }
-    };
-    public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
-    {
-        var queryParams = new Dictionary<string, object?>();
-        queryParams.Add("c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : null);
-        if (this.Transaction == null)
-        {
-            using (var connection = await GetDataSource().OpenConnectionAsync())
-            {
-                await connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams);
-                return;
-            }
-        }
-
-        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-        await this.Transaction.Connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams, transaction: this.Transaction);
-    }
-
-    private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
-                                                                  c_qualified_enum
-                                                              FROM postgres_qualified_enum_types
-                                                              LIMIT 1";
-    public class GetPostgresQualifiedEnumTypesRow
-    {
-        public CEnum? CQualifiedEnum { get; init; }
-    };
-    public async Task<GetPostgresQualifiedEnumTypesRow?> GetPostgresQualifiedEnumTypesAsync()
-    {
-        if (this.Transaction == null)
-        {
-            using (var connection = await GetDataSource().OpenConnectionAsync())
-            {
-                var result = await connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow?>(GetPostgresQualifiedEnumTypesSql);
-                return result;
-            }
-        }
-
-        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-        return await this.Transaction.Connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow?>(GetPostgresQualifiedEnumTypesSql, transaction: this.Transaction);
-    }
-
-    private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
-    public async Task TruncatePostgresQualifiedEnumTypesAsync()
-    {
-        if (this.Transaction == null)
-        {
-            using (var connection = await GetDataSource().OpenConnectionAsync())
-            {
-                await connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql);
-                return;
-            }
-        }
-
-        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-        await this.Transaction.Connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql, transaction: this.Transaction);
     }
 }

--- a/examples/NpgsqlDapperExample/QuerySql.cs
+++ b/examples/NpgsqlDapperExample/QuerySql.cs
@@ -1887,4 +1887,74 @@ public class QuerySql : IDisposable
             throw new InvalidOperationException("Transaction is provided, but its connection is null.");
         await this.Transaction.Connection.ExecuteAsync(TruncatePostgresGeoTypesSql, transaction: this.Transaction);
     }
+
+    private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
+                                                                 (
+                                                                     c_qualified_enum
+                                                                 )
+                                                                 VALUES (
+                                                                     @c_qualified_enum::c_enum
+                                                                 )";
+    public class InsertPostgresQualifiedEnumTypesArgs
+    {
+        public CEnum? CQualifiedEnum { get; init; }
+    };
+    public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
+    {
+        var queryParams = new Dictionary<string, object?>();
+        queryParams.Add("c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : null);
+        if (this.Transaction == null)
+        {
+            using (var connection = await GetDataSource().OpenConnectionAsync())
+            {
+                await connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams);
+                return;
+            }
+        }
+
+        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+        await this.Transaction.Connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams, transaction: this.Transaction);
+    }
+
+    private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
+                                                                  c_qualified_enum
+                                                              FROM postgres_qualified_enum_types
+                                                              LIMIT 1";
+    public class GetPostgresQualifiedEnumTypesRow
+    {
+        public CEnum? CQualifiedEnum { get; init; }
+    };
+    public async Task<GetPostgresQualifiedEnumTypesRow?> GetPostgresQualifiedEnumTypesAsync()
+    {
+        if (this.Transaction == null)
+        {
+            using (var connection = await GetDataSource().OpenConnectionAsync())
+            {
+                var result = await connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow?>(GetPostgresQualifiedEnumTypesSql);
+                return result;
+            }
+        }
+
+        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+        return await this.Transaction.Connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow?>(GetPostgresQualifiedEnumTypesSql, transaction: this.Transaction);
+    }
+
+    private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
+    public async Task TruncatePostgresQualifiedEnumTypesAsync()
+    {
+        if (this.Transaction == null)
+        {
+            using (var connection = await GetDataSource().OpenConnectionAsync())
+            {
+                await connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql);
+                return;
+            }
+        }
+
+        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+        await this.Transaction.Connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql, transaction: this.Transaction);
+    }
 }

--- a/examples/NpgsqlDapperExample/request.json
+++ b/examples/NpgsqlDapperExample/request.json
@@ -606,6 +606,17 @@
                 }
               },
               {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_special_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              },
+              {
                 "name": "c_json",
                 "length": -1,
                 "table": {
@@ -682,24 +693,6 @@
                   "name": "postgres_not_null_types"
                 },
                 "type": {
-                  "name": "c_enum"
-                }
-              }
-            ]
-          },
-          {
-            "rel": {
-              "name": "postgres_qualified_enum_types"
-            },
-            "columns": [
-              {
-                "name": "c_qualified_enum",
-                "length": -1,
-                "table": {
-                  "name": "postgres_qualified_enum_types"
-                },
-                "type": {
-                  "schema": "public",
                   "name": "c_enum"
                 }
               }
@@ -35108,7 +35101,7 @@
       }
     },
     {
-      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum\n)",
+      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum,\n    $9::c_enum\n)",
       "name": "InsertPostgresSpecialTypes",
       "cmd": ":exec",
       "parameters": [
@@ -35210,6 +35203,16 @@
               "name": "c_enum"
             }
           }
+        },
+        {
+          "number": 9,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
         }
       ],
       "comments": [
@@ -35269,7 +35272,7 @@
       "filename": "query.sql"
     },
     {
-      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\nFROM postgres_special_types \nLIMIT 1",
+      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\nFROM postgres_special_types \nLIMIT 1",
       "name": "GetPostgresSpecialTypes",
       "cmd": ":one",
       "columns": [
@@ -35362,6 +35365,18 @@
             "name": "c_enum"
           },
           "originalName": "c_enum"
+        },
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_special_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
         }
       ],
       "filename": "query.sql"
@@ -36245,53 +36260,6 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
-      "cmd": ":exec",
-      "filename": "query.sql"
-    },
-    {
-      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
-      "name": "InsertPostgresQualifiedEnumTypes",
-      "cmd": ":exec",
-      "parameters": [
-        {
-          "number": 1,
-          "column": {
-            "name": "c_qualified_enum",
-            "length": -1,
-            "type": {
-              "name": "c_enum"
-            }
-          }
-        }
-      ],
-      "filename": "query.sql",
-      "insert_into_table": {
-        "name": "postgres_qualified_enum_types"
-      }
-    },
-    {
-      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
-      "name": "GetPostgresQualifiedEnumTypes",
-      "cmd": ":one",
-      "columns": [
-        {
-          "name": "c_qualified_enum",
-          "length": -1,
-          "table": {
-            "name": "postgres_qualified_enum_types"
-          },
-          "type": {
-            "schema": "public",
-            "name": "c_enum"
-          },
-          "originalName": "c_qualified_enum"
-        }
-      ],
-      "filename": "query.sql"
-    },
-    {
-      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
-      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlDapperExample/request.json
+++ b/examples/NpgsqlDapperExample/request.json
@@ -686,6 +686,24 @@
                 }
               }
             ]
+          },
+          {
+            "rel": {
+              "name": "postgres_qualified_enum_types"
+            },
+            "columns": [
+              {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_qualified_enum_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              }
+            ]
           }
         ],
         "enums": [
@@ -36227,6 +36245,53 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
+      "cmd": ":exec",
+      "filename": "query.sql"
+    },
+    {
+      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
+      "name": "InsertPostgresQualifiedEnumTypes",
+      "cmd": ":exec",
+      "parameters": [
+        {
+          "number": 1,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
+        }
+      ],
+      "filename": "query.sql",
+      "insert_into_table": {
+        "name": "postgres_qualified_enum_types"
+      }
+    },
+    {
+      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
+      "name": "GetPostgresQualifiedEnumTypes",
+      "cmd": ":one",
+      "columns": [
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_qualified_enum_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
+        }
+      ],
+      "filename": "query.sql"
+    },
+    {
+      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
+      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlDapperExample/request.message
+++ b/examples/NpgsqlDapperExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlb‡
 examples/NpgsqlDapperExamplecsharpÈ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlDapperExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"net8.0","useDapper":true}*
-./dist/LocalRunner¡îpublic"ãpublicƒ
+./dist/LocalRunner–ïpublic"Øpublicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -98,7 +98,9 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
+postgres_qualified_enum_typesP
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10917,4 +10919,18 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*º{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlDapperExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
+\INSERT INTO postgres_qualified_enum_types
+(
+    c_qualified_enum
+)
+VALUES (
+    $1::c_enum
+) InsertPostgresQualifiedEnumTypes:exec*+'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
+FSELECT
+    c_qualified_enum
+FROM postgres_qualified_enum_types
+LIMIT 1GetPostgresQualifiedEnumTypes:one"b
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
+,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*º{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlDapperExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/NpgsqlDapperExample/request.message
+++ b/examples/NpgsqlDapperExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlb‡
 examples/NpgsqlDapperExamplecsharpÈ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlDapperExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"net8.0","useDapper":true}*
-./dist/LocalRunner–ïpublic"Øpublicƒ
+./dist/LocalRunnerìîpublic"®publicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -83,10 +83,11 @@ pg_catalog	timestampˆµ
 c_box0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbbox7
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpath=
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygon;
-c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircle’
+c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircleÝ
 postgres_special_types5
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuid7
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumA
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumI
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumA
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 pg_catalogjsonQ
 c_json_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -98,9 +99,7 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
-postgres_qualified_enum_typesP
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10682,8 +10681,8 @@ LIMIT 1GetPostgresNetworkTypesCnt:one"=
 ) VALUES ($1, $2, $3)InsertPostgresNetworkTypesBatch	:copyfrom*IE
 c_cidr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbcidrzc_cidr*IE
 c_inet0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbinetzc_inet*RN
-	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types¿
-—
+	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types’
+½
 INSERT INTO postgres_special_types
 (
     c_json,
@@ -10693,7 +10692,8 @@ INSERT INTO postgres_special_types
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 )
 VALUES (
     $1, 
@@ -10703,7 +10703,8 @@ VALUES (
     $5::xml,
     $6::xml,
     $7,
-    $8::c_enum
+    $8::c_enum,
+    $9::c_enum
 )InsertPostgresSpecialTypes:exec*VR
 c_json0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbpg_catalog.jsonzc_json*;7
 c_json_string_override0ÿÿÿÿÿÿÿÿÿb
@@ -10715,7 +10716,8 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿb
 c_xml0ÿÿÿÿÿÿÿÿÿbxml*-)
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿbxml*KG
 c_uuid0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbuuidzc_uuid*!
-c_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
+c_enum0ÿÿÿÿÿÿÿÿÿbc_enum*+	'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
 UINSERT INTO postgres_not_null_types
 (
     c_enum_not_null
@@ -10729,8 +10731,8 @@ VALUES (
 FROM postgres_not_null_types 
 LIMIT 1GetPostgresNotNullTypes:one"T
 c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enumzc_enum_not_null:	query.sqlX
-&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sqlµ
-­SELECT
+&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sql¨
+ÃSELECT
     c_json,
     c_json_string_override,
     c_jsonb,
@@ -10738,7 +10740,8 @@ LIMIT 1GetPostgresNotNullTypes:one"T
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 FROM postgres_special_types 
 LIMIT 1GetPostgresSpecialTypes:one"I
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -10753,7 +10756,8 @@ c_jsonpath":
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml"Z
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml_string_override"=
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuidzc_uuid"?
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum:	query.sqlW
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum"[
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumzc_qualified_enum:	query.sqlW
 %TRUNCATE TABLE postgres_special_typesTruncatePostgresSpecialTypes:exec:	query.sql®
 lINSERT INTO postgres_special_types
 (
@@ -10919,18 +10923,4 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
-\INSERT INTO postgres_qualified_enum_types
-(
-    c_qualified_enum
-)
-VALUES (
-    $1::c_enum
-) InsertPostgresQualifiedEnumTypes:exec*+'
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
-FSELECT
-    c_qualified_enum
-FROM postgres_qualified_enum_types
-LIMIT 1GetPostgresQualifiedEnumTypes:one"b
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
-,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*º{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlDapperExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*º{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlDapperExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/NpgsqlDapperLegacyExample/Models.cs
+++ b/examples/NpgsqlDapperLegacyExample/Models.cs
@@ -97,6 +97,10 @@ namespace NpgsqlDapperLegacyExampleGen
     {
         public CEnum CEnumNotNull { get; set; }
     };
+    public class PostgresQualifiedEnumType
+    {
+        public CEnum? CQualifiedEnum { get; set; }
+    };
     public class ExtendedBio
     {
         public string AuthorName { get; set; }

--- a/examples/NpgsqlDapperLegacyExample/Models.cs
+++ b/examples/NpgsqlDapperLegacyExample/Models.cs
@@ -86,6 +86,7 @@ namespace NpgsqlDapperLegacyExampleGen
     {
         public Guid? CUuid { get; set; }
         public CEnum? CEnum { get; set; }
+        public CEnum? CQualifiedEnum { get; set; }
         public JsonElement? CJson { get; set; }
         public JsonElement? CJsonStringOverride { get; set; }
         public JsonElement? CJsonb { get; set; }
@@ -96,10 +97,6 @@ namespace NpgsqlDapperLegacyExampleGen
     public class PostgresNotNullType
     {
         public CEnum CEnumNotNull { get; set; }
-    };
-    public class PostgresQualifiedEnumType
-    {
-        public CEnum? CQualifiedEnum { get; set; }
     };
     public class ExtendedBio
     {

--- a/examples/NpgsqlDapperLegacyExample/QuerySql.cs
+++ b/examples/NpgsqlDapperLegacyExample/QuerySql.cs
@@ -1888,5 +1888,75 @@ namespace NpgsqlDapperLegacyExampleGen
                 throw new InvalidOperationException("Transaction is provided, but its connection is null.");
             await this.Transaction.Connection.ExecuteAsync(TruncatePostgresGeoTypesSql, transaction: this.Transaction);
         }
+
+        private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
+                                                                     (
+                                                                         c_qualified_enum
+                                                                     )
+                                                                     VALUES (
+                                                                         @c_qualified_enum::c_enum
+                                                                     )";
+        public class InsertPostgresQualifiedEnumTypesArgs
+        {
+            public CEnum? CQualifiedEnum { get; set; }
+        };
+        public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
+        {
+            var queryParams = new Dictionary<string, object>();
+            queryParams.Add("c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : null);
+            if (this.Transaction == null)
+            {
+                using (var connection = await GetDataSource().OpenConnectionAsync())
+                {
+                    await connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams);
+                    return;
+                }
+            }
+
+            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+            await this.Transaction.Connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams, transaction: this.Transaction);
+        }
+
+        private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
+                                                                      c_qualified_enum
+                                                                  FROM postgres_qualified_enum_types
+                                                                  LIMIT 1";
+        public class GetPostgresQualifiedEnumTypesRow
+        {
+            public CEnum? CQualifiedEnum { get; set; }
+        };
+        public async Task<GetPostgresQualifiedEnumTypesRow> GetPostgresQualifiedEnumTypesAsync()
+        {
+            if (this.Transaction == null)
+            {
+                using (var connection = await GetDataSource().OpenConnectionAsync())
+                {
+                    var result = await connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow>(GetPostgresQualifiedEnumTypesSql);
+                    return result;
+                }
+            }
+
+            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+            return await this.Transaction.Connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow>(GetPostgresQualifiedEnumTypesSql, transaction: this.Transaction);
+        }
+
+        private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
+        public async Task TruncatePostgresQualifiedEnumTypesAsync()
+        {
+            if (this.Transaction == null)
+            {
+                using (var connection = await GetDataSource().OpenConnectionAsync())
+                {
+                    await connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql);
+                    return;
+                }
+            }
+
+            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+            await this.Transaction.Connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql, transaction: this.Transaction);
+        }
     }
 }

--- a/examples/NpgsqlDapperLegacyExample/QuerySql.cs
+++ b/examples/NpgsqlDapperLegacyExample/QuerySql.cs
@@ -1359,7 +1359,8 @@ namespace NpgsqlDapperLegacyExampleGen
                                                                    c_xml,
                                                                    c_xml_string_override,
                                                                    c_uuid,
-                                                                   c_enum
+                                                                   c_enum,
+                                                                   c_qualified_enum
                                                                )
                                                                VALUES (
                                                                    @c_json, 
@@ -1369,7 +1370,8 @@ namespace NpgsqlDapperLegacyExampleGen
                                                                    @c_xml::xml,
                                                                    @c_xml_string_override::xml,
                                                                    @c_uuid,
-                                                                   @c_enum::c_enum
+                                                                   @c_enum::c_enum,
+                                                                   @c_qualified_enum::c_enum
                                                                )";
         public class InsertPostgresSpecialTypesArgs
         {
@@ -1381,6 +1383,7 @@ namespace NpgsqlDapperLegacyExampleGen
             public string CXmlStringOverride { get; set; }
             public Guid? CUuid { get; set; }
             public CEnum? CEnum { get; set; }
+            public CEnum? CQualifiedEnum { get; set; }
         };
         public async Task InsertPostgresSpecialTypesAsync(InsertPostgresSpecialTypesArgs args)
         {
@@ -1393,6 +1396,7 @@ namespace NpgsqlDapperLegacyExampleGen
             queryParams.Add("c_xml_string_override", args.CXmlStringOverride);
             queryParams.Add("c_uuid", args.CUuid);
             queryParams.Add("c_enum", args.CEnum != null ? args.CEnum.Value.Stringify() : null);
+            queryParams.Add("c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : null);
             if (this.Transaction == null)
             {
                 using (var connection = await GetDataSource().OpenConnectionAsync())
@@ -1485,7 +1489,8 @@ namespace NpgsqlDapperLegacyExampleGen
                                                                 c_xml,
                                                                 c_xml_string_override,
                                                                 c_uuid,
-                                                                c_enum
+                                                                c_enum,
+                                                                c_qualified_enum
                                                             FROM postgres_special_types 
                                                             LIMIT 1";
         public class GetPostgresSpecialTypesRow
@@ -1498,6 +1503,7 @@ namespace NpgsqlDapperLegacyExampleGen
             public string CXmlStringOverride { get; set; }
             public Guid? CUuid { get; set; }
             public CEnum? CEnum { get; set; }
+            public CEnum? CQualifiedEnum { get; set; }
         };
         public async Task<GetPostgresSpecialTypesRow> GetPostgresSpecialTypesAsync()
         {
@@ -1887,76 +1893,6 @@ namespace NpgsqlDapperLegacyExampleGen
             if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
                 throw new InvalidOperationException("Transaction is provided, but its connection is null.");
             await this.Transaction.Connection.ExecuteAsync(TruncatePostgresGeoTypesSql, transaction: this.Transaction);
-        }
-
-        private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
-                                                                     (
-                                                                         c_qualified_enum
-                                                                     )
-                                                                     VALUES (
-                                                                         @c_qualified_enum::c_enum
-                                                                     )";
-        public class InsertPostgresQualifiedEnumTypesArgs
-        {
-            public CEnum? CQualifiedEnum { get; set; }
-        };
-        public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
-        {
-            var queryParams = new Dictionary<string, object>();
-            queryParams.Add("c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : null);
-            if (this.Transaction == null)
-            {
-                using (var connection = await GetDataSource().OpenConnectionAsync())
-                {
-                    await connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams);
-                    return;
-                }
-            }
-
-            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-            await this.Transaction.Connection.ExecuteAsync(InsertPostgresQualifiedEnumTypesSql, queryParams, transaction: this.Transaction);
-        }
-
-        private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
-                                                                      c_qualified_enum
-                                                                  FROM postgres_qualified_enum_types
-                                                                  LIMIT 1";
-        public class GetPostgresQualifiedEnumTypesRow
-        {
-            public CEnum? CQualifiedEnum { get; set; }
-        };
-        public async Task<GetPostgresQualifiedEnumTypesRow> GetPostgresQualifiedEnumTypesAsync()
-        {
-            if (this.Transaction == null)
-            {
-                using (var connection = await GetDataSource().OpenConnectionAsync())
-                {
-                    var result = await connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow>(GetPostgresQualifiedEnumTypesSql);
-                    return result;
-                }
-            }
-
-            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-            return await this.Transaction.Connection.QueryFirstOrDefaultAsync<GetPostgresQualifiedEnumTypesRow>(GetPostgresQualifiedEnumTypesSql, transaction: this.Transaction);
-        }
-
-        private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
-        public async Task TruncatePostgresQualifiedEnumTypesAsync()
-        {
-            if (this.Transaction == null)
-            {
-                using (var connection = await GetDataSource().OpenConnectionAsync())
-                {
-                    await connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql);
-                    return;
-                }
-            }
-
-            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-            await this.Transaction.Connection.ExecuteAsync(TruncatePostgresQualifiedEnumTypesSql, transaction: this.Transaction);
         }
     }
 }

--- a/examples/NpgsqlDapperLegacyExample/request.json
+++ b/examples/NpgsqlDapperLegacyExample/request.json
@@ -606,6 +606,17 @@
                 }
               },
               {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_special_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              },
+              {
                 "name": "c_json",
                 "length": -1,
                 "table": {
@@ -682,24 +693,6 @@
                   "name": "postgres_not_null_types"
                 },
                 "type": {
-                  "name": "c_enum"
-                }
-              }
-            ]
-          },
-          {
-            "rel": {
-              "name": "postgres_qualified_enum_types"
-            },
-            "columns": [
-              {
-                "name": "c_qualified_enum",
-                "length": -1,
-                "table": {
-                  "name": "postgres_qualified_enum_types"
-                },
-                "type": {
-                  "schema": "public",
                   "name": "c_enum"
                 }
               }
@@ -35108,7 +35101,7 @@
       }
     },
     {
-      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum\n)",
+      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum,\n    $9::c_enum\n)",
       "name": "InsertPostgresSpecialTypes",
       "cmd": ":exec",
       "parameters": [
@@ -35210,6 +35203,16 @@
               "name": "c_enum"
             }
           }
+        },
+        {
+          "number": 9,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
         }
       ],
       "comments": [
@@ -35269,7 +35272,7 @@
       "filename": "query.sql"
     },
     {
-      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\nFROM postgres_special_types \nLIMIT 1",
+      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\nFROM postgres_special_types \nLIMIT 1",
       "name": "GetPostgresSpecialTypes",
       "cmd": ":one",
       "columns": [
@@ -35362,6 +35365,18 @@
             "name": "c_enum"
           },
           "originalName": "c_enum"
+        },
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_special_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
         }
       ],
       "filename": "query.sql"
@@ -36245,53 +36260,6 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
-      "cmd": ":exec",
-      "filename": "query.sql"
-    },
-    {
-      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
-      "name": "InsertPostgresQualifiedEnumTypes",
-      "cmd": ":exec",
-      "parameters": [
-        {
-          "number": 1,
-          "column": {
-            "name": "c_qualified_enum",
-            "length": -1,
-            "type": {
-              "name": "c_enum"
-            }
-          }
-        }
-      ],
-      "filename": "query.sql",
-      "insert_into_table": {
-        "name": "postgres_qualified_enum_types"
-      }
-    },
-    {
-      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
-      "name": "GetPostgresQualifiedEnumTypes",
-      "cmd": ":one",
-      "columns": [
-        {
-          "name": "c_qualified_enum",
-          "length": -1,
-          "table": {
-            "name": "postgres_qualified_enum_types"
-          },
-          "type": {
-            "schema": "public",
-            "name": "c_enum"
-          },
-          "originalName": "c_qualified_enum"
-        }
-      ],
-      "filename": "query.sql"
-    },
-    {
-      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
-      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlDapperLegacyExample/request.json
+++ b/examples/NpgsqlDapperLegacyExample/request.json
@@ -686,6 +686,24 @@
                 }
               }
             ]
+          },
+          {
+            "rel": {
+              "name": "postgres_qualified_enum_types"
+            },
+            "columns": [
+              {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_qualified_enum_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              }
+            ]
           }
         ],
         "enums": [
@@ -36227,6 +36245,53 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
+      "cmd": ":exec",
+      "filename": "query.sql"
+    },
+    {
+      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
+      "name": "InsertPostgresQualifiedEnumTypes",
+      "cmd": ":exec",
+      "parameters": [
+        {
+          "number": 1,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
+        }
+      ],
+      "filename": "query.sql",
+      "insert_into_table": {
+        "name": "postgres_qualified_enum_types"
+      }
+    },
+    {
+      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
+      "name": "GetPostgresQualifiedEnumTypes",
+      "cmd": ":one",
+      "columns": [
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_qualified_enum_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
+        }
+      ],
+      "filename": "query.sql"
+    },
+    {
+      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
+      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlDapperLegacyExample/request.message
+++ b/examples/NpgsqlDapperLegacyExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlb›
 "examples/NpgsqlDapperLegacyExamplecsharpÖ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlDapperLegacyExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"netstandard2.0","useDapper":true}*
-./dist/LocalRunner¡îpublic"ãpublicƒ
+./dist/LocalRunner–ïpublic"Øpublicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -98,7 +98,9 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
+postgres_qualified_enum_typesP
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10917,4 +10919,18 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*È{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlDapperLegacyExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
+\INSERT INTO postgres_qualified_enum_types
+(
+    c_qualified_enum
+)
+VALUES (
+    $1::c_enum
+) InsertPostgresQualifiedEnumTypes:exec*+'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
+FSELECT
+    c_qualified_enum
+FROM postgres_qualified_enum_types
+LIMIT 1GetPostgresQualifiedEnumTypes:one"b
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
+,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*È{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlDapperLegacyExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/NpgsqlDapperLegacyExample/request.message
+++ b/examples/NpgsqlDapperLegacyExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlb›
 "examples/NpgsqlDapperLegacyExamplecsharpÖ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlDapperLegacyExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"netstandard2.0","useDapper":true}*
-./dist/LocalRunner–ïpublic"Øpublicƒ
+./dist/LocalRunnerìîpublic"®publicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -83,10 +83,11 @@ pg_catalog	timestampˆµ
 c_box0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbbox7
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpath=
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygon;
-c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircle’
+c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircleÝ
 postgres_special_types5
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuid7
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumA
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumI
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumA
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 pg_catalogjsonQ
 c_json_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -98,9 +99,7 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
-postgres_qualified_enum_typesP
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10682,8 +10681,8 @@ LIMIT 1GetPostgresNetworkTypesCnt:one"=
 ) VALUES ($1, $2, $3)InsertPostgresNetworkTypesBatch	:copyfrom*IE
 c_cidr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbcidrzc_cidr*IE
 c_inet0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbinetzc_inet*RN
-	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types¿
-—
+	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types’
+½
 INSERT INTO postgres_special_types
 (
     c_json,
@@ -10693,7 +10692,8 @@ INSERT INTO postgres_special_types
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 )
 VALUES (
     $1, 
@@ -10703,7 +10703,8 @@ VALUES (
     $5::xml,
     $6::xml,
     $7,
-    $8::c_enum
+    $8::c_enum,
+    $9::c_enum
 )InsertPostgresSpecialTypes:exec*VR
 c_json0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbpg_catalog.jsonzc_json*;7
 c_json_string_override0ÿÿÿÿÿÿÿÿÿb
@@ -10715,7 +10716,8 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿb
 c_xml0ÿÿÿÿÿÿÿÿÿbxml*-)
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿbxml*KG
 c_uuid0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbuuidzc_uuid*!
-c_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
+c_enum0ÿÿÿÿÿÿÿÿÿbc_enum*+	'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
 UINSERT INTO postgres_not_null_types
 (
     c_enum_not_null
@@ -10729,8 +10731,8 @@ VALUES (
 FROM postgres_not_null_types 
 LIMIT 1GetPostgresNotNullTypes:one"T
 c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enumzc_enum_not_null:	query.sqlX
-&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sqlµ
-­SELECT
+&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sql¨
+ÃSELECT
     c_json,
     c_json_string_override,
     c_jsonb,
@@ -10738,7 +10740,8 @@ LIMIT 1GetPostgresNotNullTypes:one"T
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 FROM postgres_special_types 
 LIMIT 1GetPostgresSpecialTypes:one"I
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -10753,7 +10756,8 @@ c_jsonpath":
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml"Z
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml_string_override"=
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuidzc_uuid"?
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum:	query.sqlW
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum"[
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumzc_qualified_enum:	query.sqlW
 %TRUNCATE TABLE postgres_special_typesTruncatePostgresSpecialTypes:exec:	query.sql®
 lINSERT INTO postgres_special_types
 (
@@ -10919,18 +10923,4 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
-\INSERT INTO postgres_qualified_enum_types
-(
-    c_qualified_enum
-)
-VALUES (
-    $1::c_enum
-) InsertPostgresQualifiedEnumTypes:exec*+'
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
-FSELECT
-    c_qualified_enum
-FROM postgres_qualified_enum_types
-LIMIT 1GetPostgresQualifiedEnumTypes:one"b
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
-,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*È{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlDapperLegacyExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*È{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlDapperLegacyExampleGen","useDapper":true,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/NpgsqlExample/Models.cs
+++ b/examples/NpgsqlExample/Models.cs
@@ -19,9 +19,8 @@ public readonly record struct PostgresDatetimeType(DateTime? CDate, TimeSpan? CT
 public readonly record struct PostgresNetworkType(NpgsqlCidr? CCidr, IPAddress? CInet, PhysicalAddress? CMacaddr, string? CMacaddr8);
 public readonly record struct PostgresArrayType(byte[]? CBytea, bool[]? CBooleanArray, string[]? CTextArray, int[]? CIntegerArray, decimal[]? CDecimalArray, DateTime[]? CDateArray, DateTime[]? CTimestampArray);
 public readonly record struct PostgresGeometricType(NpgsqlPoint? CPoint, NpgsqlLine? CLine, NpgsqlLSeg? CLseg, NpgsqlBox? CBox, NpgsqlPath? CPath, NpgsqlPolygon? CPolygon, NpgsqlCircle? CCircle);
-public readonly record struct PostgresSpecialType(Guid? CUuid, CEnum? CEnum, JsonElement? CJson, JsonElement? CJsonStringOverride, JsonElement? CJsonb, string? CJsonpath, XmlDocument? CXml, XmlDocument? CXmlStringOverride);
+public readonly record struct PostgresSpecialType(Guid? CUuid, CEnum? CEnum, CEnum? CQualifiedEnum, JsonElement? CJson, JsonElement? CJsonStringOverride, JsonElement? CJsonb, string? CJsonpath, XmlDocument? CXml, XmlDocument? CXmlStringOverride);
 public readonly record struct PostgresNotNullType(CEnum CEnumNotNull);
-public readonly record struct PostgresQualifiedEnumType(CEnum? CQualifiedEnum);
 public readonly record struct ExtendedBio(string AuthorName, string Name, ExtendedBioType? BioType);
 public enum CEnum
 {

--- a/examples/NpgsqlExample/Models.cs
+++ b/examples/NpgsqlExample/Models.cs
@@ -21,6 +21,7 @@ public readonly record struct PostgresArrayType(byte[]? CBytea, bool[]? CBoolean
 public readonly record struct PostgresGeometricType(NpgsqlPoint? CPoint, NpgsqlLine? CLine, NpgsqlLSeg? CLseg, NpgsqlBox? CBox, NpgsqlPath? CPath, NpgsqlPolygon? CPolygon, NpgsqlCircle? CCircle);
 public readonly record struct PostgresSpecialType(Guid? CUuid, CEnum? CEnum, JsonElement? CJson, JsonElement? CJsonStringOverride, JsonElement? CJsonb, string? CJsonpath, XmlDocument? CXml, XmlDocument? CXmlStringOverride);
 public readonly record struct PostgresNotNullType(CEnum CEnumNotNull);
+public readonly record struct PostgresQualifiedEnumType(CEnum? CQualifiedEnum);
 public readonly record struct ExtendedBio(string AuthorName, string Name, ExtendedBioType? BioType);
 public enum CEnum
 {

--- a/examples/NpgsqlExample/QuerySql.cs
+++ b/examples/NpgsqlExample/QuerySql.cs
@@ -2660,4 +2660,117 @@ public class QuerySql : IDisposable
             await command.ExecuteNonQueryAsync();
         }
     }
+
+    private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
+                                                                 (
+                                                                     c_qualified_enum
+                                                                 )
+                                                                 VALUES (
+                                                                     @c_qualified_enum::c_enum
+                                                                 )";
+    public readonly record struct InsertPostgresQualifiedEnumTypesArgs(CEnum? CQualifiedEnum);
+    public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
+    {
+        if (this.Transaction == null)
+        {
+            using (var connection = await GetDataSource().OpenConnectionAsync())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = InsertPostgresQualifiedEnumTypesSql;
+                    command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
+                    await command.ExecuteNonQueryAsync();
+                }
+
+                return;
+            }
+        }
+
+        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+        using (var command = this.Transaction.Connection.CreateCommand())
+        {
+            command.CommandText = InsertPostgresQualifiedEnumTypesSql;
+            command.Transaction = this.Transaction;
+            command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
+                                                                  c_qualified_enum
+                                                              FROM postgres_qualified_enum_types
+                                                              LIMIT 1";
+    public readonly record struct GetPostgresQualifiedEnumTypesRow(CEnum? CQualifiedEnum);
+    public async Task<GetPostgresQualifiedEnumTypesRow?> GetPostgresQualifiedEnumTypesAsync()
+    {
+        if (this.Transaction == null)
+        {
+            using (var connection = await GetDataSource().OpenConnectionAsync())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = GetPostgresQualifiedEnumTypesSql;
+                    using (var reader = await command.ExecuteReaderAsync())
+                    {
+                        if (await reader.ReadAsync())
+                        {
+                            return new GetPostgresQualifiedEnumTypesRow
+                            {
+                                CQualifiedEnum = reader.IsDBNull(0) ? null : reader.GetString(0).ToCEnum()
+                            };
+                        }
+                    }
+                }
+            };
+            return null;
+        }
+
+        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+        using (var command = this.Transaction.Connection.CreateCommand())
+        {
+            command.CommandText = GetPostgresQualifiedEnumTypesSql;
+            command.Transaction = this.Transaction;
+            using (var reader = await command.ExecuteReaderAsync())
+            {
+                if (await reader.ReadAsync())
+                {
+                    return new GetPostgresQualifiedEnumTypesRow
+                    {
+                        CQualifiedEnum = reader.IsDBNull(0) ? null : reader.GetString(0).ToCEnum()
+                    };
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
+    public async Task TruncatePostgresQualifiedEnumTypesAsync()
+    {
+        if (this.Transaction == null)
+        {
+            using (var connection = await GetDataSource().OpenConnectionAsync())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
+                    await command.ExecuteNonQueryAsync();
+                }
+
+                return;
+            }
+        }
+
+        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+        using (var command = this.Transaction.Connection.CreateCommand())
+        {
+            command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
+            command.Transaction = this.Transaction;
+            await command.ExecuteNonQueryAsync();
+        }
+    }
 }

--- a/examples/NpgsqlExample/QuerySql.cs
+++ b/examples/NpgsqlExample/QuerySql.cs
@@ -1891,7 +1891,8 @@ public class QuerySql : IDisposable
                                                                c_xml,
                                                                c_xml_string_override,
                                                                c_uuid,
-                                                               c_enum
+                                                               c_enum,
+                                                               c_qualified_enum
                                                            )
                                                            VALUES (
                                                                @c_json, 
@@ -1901,9 +1902,10 @@ public class QuerySql : IDisposable
                                                                @c_xml::xml,
                                                                @c_xml_string_override::xml,
                                                                @c_uuid,
-                                                               @c_enum::c_enum
+                                                               @c_enum::c_enum,
+                                                               @c_qualified_enum::c_enum
                                                            )";
-    public readonly record struct InsertPostgresSpecialTypesArgs(JsonElement? CJson, string? CJsonStringOverride, JsonElement? CJsonb, string? CJsonpath, XmlDocument? CXml, string? CXmlStringOverride, Guid? CUuid, CEnum? CEnum);
+    public readonly record struct InsertPostgresSpecialTypesArgs(JsonElement? CJson, string? CJsonStringOverride, JsonElement? CJsonb, string? CJsonpath, XmlDocument? CXml, string? CXmlStringOverride, Guid? CUuid, CEnum? CEnum, CEnum? CQualifiedEnum);
     public async Task InsertPostgresSpecialTypesAsync(InsertPostgresSpecialTypesArgs args)
     {
         if (this.Transaction == null)
@@ -1921,6 +1923,7 @@ public class QuerySql : IDisposable
                     command.Parameters.AddWithValue("@c_xml_string_override", NpgsqlDbType.Xml, args.CXmlStringOverride ?? (object)DBNull.Value);
                     command.Parameters.AddWithValue("@c_uuid", args.CUuid ?? (object)DBNull.Value);
                     command.Parameters.AddWithValue("@c_enum", args.CEnum != null ? args.CEnum.Value.Stringify() : (object)DBNull.Value);
+                    command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
                     await command.ExecuteNonQueryAsync();
                 }
 
@@ -1942,6 +1945,7 @@ public class QuerySql : IDisposable
             command.Parameters.AddWithValue("@c_xml_string_override", NpgsqlDbType.Xml, args.CXmlStringOverride ?? (object)DBNull.Value);
             command.Parameters.AddWithValue("@c_uuid", args.CUuid ?? (object)DBNull.Value);
             command.Parameters.AddWithValue("@c_enum", args.CEnum != null ? args.CEnum.Value.Stringify() : (object)DBNull.Value);
+            command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
             await command.ExecuteNonQueryAsync();
         }
     }
@@ -2067,10 +2071,11 @@ public class QuerySql : IDisposable
                                                             c_xml,
                                                             c_xml_string_override,
                                                             c_uuid,
-                                                            c_enum
+                                                            c_enum,
+                                                            c_qualified_enum
                                                         FROM postgres_special_types 
                                                         LIMIT 1";
-    public readonly record struct GetPostgresSpecialTypesRow(JsonElement? CJson, string? CJsonStringOverride, JsonElement? CJsonb, string? CJsonpath, XmlDocument? CXml, string? CXmlStringOverride, Guid? CUuid, CEnum? CEnum);
+    public readonly record struct GetPostgresSpecialTypesRow(JsonElement? CJson, string? CJsonStringOverride, JsonElement? CJsonb, string? CJsonpath, XmlDocument? CXml, string? CXmlStringOverride, Guid? CUuid, CEnum? CEnum, CEnum? CQualifiedEnum);
     public async Task<GetPostgresSpecialTypesRow?> GetPostgresSpecialTypesAsync()
     {
         if (this.Transaction == null)
@@ -2098,7 +2103,8 @@ public class QuerySql : IDisposable
                                 }))(reader, 4),
                                 CXmlStringOverride = reader.IsDBNull(5) ? null : reader.GetString(5),
                                 CUuid = reader.IsDBNull(6) ? null : reader.GetFieldValue<Guid>(6),
-                                CEnum = reader.IsDBNull(7) ? null : reader.GetString(7).ToCEnum()
+                                CEnum = reader.IsDBNull(7) ? null : reader.GetString(7).ToCEnum(),
+                                CQualifiedEnum = reader.IsDBNull(8) ? null : reader.GetString(8).ToCEnum()
                             };
                         }
                     }
@@ -2131,7 +2137,8 @@ public class QuerySql : IDisposable
                         }))(reader, 4),
                         CXmlStringOverride = reader.IsDBNull(5) ? null : reader.GetString(5),
                         CUuid = reader.IsDBNull(6) ? null : reader.GetFieldValue<Guid>(6),
-                        CEnum = reader.IsDBNull(7) ? null : reader.GetString(7).ToCEnum()
+                        CEnum = reader.IsDBNull(7) ? null : reader.GetString(7).ToCEnum(),
+                        CQualifiedEnum = reader.IsDBNull(8) ? null : reader.GetString(8).ToCEnum()
                     };
                 }
             }
@@ -2656,119 +2663,6 @@ public class QuerySql : IDisposable
         using (var command = this.Transaction.Connection.CreateCommand())
         {
             command.CommandText = TruncatePostgresGeoTypesSql;
-            command.Transaction = this.Transaction;
-            await command.ExecuteNonQueryAsync();
-        }
-    }
-
-    private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
-                                                                 (
-                                                                     c_qualified_enum
-                                                                 )
-                                                                 VALUES (
-                                                                     @c_qualified_enum::c_enum
-                                                                 )";
-    public readonly record struct InsertPostgresQualifiedEnumTypesArgs(CEnum? CQualifiedEnum);
-    public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
-    {
-        if (this.Transaction == null)
-        {
-            using (var connection = await GetDataSource().OpenConnectionAsync())
-            {
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = InsertPostgresQualifiedEnumTypesSql;
-                    command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
-                    await command.ExecuteNonQueryAsync();
-                }
-
-                return;
-            }
-        }
-
-        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-        using (var command = this.Transaction.Connection.CreateCommand())
-        {
-            command.CommandText = InsertPostgresQualifiedEnumTypesSql;
-            command.Transaction = this.Transaction;
-            command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
-            await command.ExecuteNonQueryAsync();
-        }
-    }
-
-    private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
-                                                                  c_qualified_enum
-                                                              FROM postgres_qualified_enum_types
-                                                              LIMIT 1";
-    public readonly record struct GetPostgresQualifiedEnumTypesRow(CEnum? CQualifiedEnum);
-    public async Task<GetPostgresQualifiedEnumTypesRow?> GetPostgresQualifiedEnumTypesAsync()
-    {
-        if (this.Transaction == null)
-        {
-            using (var connection = await GetDataSource().OpenConnectionAsync())
-            {
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = GetPostgresQualifiedEnumTypesSql;
-                    using (var reader = await command.ExecuteReaderAsync())
-                    {
-                        if (await reader.ReadAsync())
-                        {
-                            return new GetPostgresQualifiedEnumTypesRow
-                            {
-                                CQualifiedEnum = reader.IsDBNull(0) ? null : reader.GetString(0).ToCEnum()
-                            };
-                        }
-                    }
-                }
-            };
-            return null;
-        }
-
-        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-        using (var command = this.Transaction.Connection.CreateCommand())
-        {
-            command.CommandText = GetPostgresQualifiedEnumTypesSql;
-            command.Transaction = this.Transaction;
-            using (var reader = await command.ExecuteReaderAsync())
-            {
-                if (await reader.ReadAsync())
-                {
-                    return new GetPostgresQualifiedEnumTypesRow
-                    {
-                        CQualifiedEnum = reader.IsDBNull(0) ? null : reader.GetString(0).ToCEnum()
-                    };
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
-    public async Task TruncatePostgresQualifiedEnumTypesAsync()
-    {
-        if (this.Transaction == null)
-        {
-            using (var connection = await GetDataSource().OpenConnectionAsync())
-            {
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
-                    await command.ExecuteNonQueryAsync();
-                }
-
-                return;
-            }
-        }
-
-        if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-            throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-        using (var command = this.Transaction.Connection.CreateCommand())
-        {
-            command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
             command.Transaction = this.Transaction;
             await command.ExecuteNonQueryAsync();
         }

--- a/examples/NpgsqlExample/request.json
+++ b/examples/NpgsqlExample/request.json
@@ -606,6 +606,17 @@
                 }
               },
               {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_special_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              },
+              {
                 "name": "c_json",
                 "length": -1,
                 "table": {
@@ -682,24 +693,6 @@
                   "name": "postgres_not_null_types"
                 },
                 "type": {
-                  "name": "c_enum"
-                }
-              }
-            ]
-          },
-          {
-            "rel": {
-              "name": "postgres_qualified_enum_types"
-            },
-            "columns": [
-              {
-                "name": "c_qualified_enum",
-                "length": -1,
-                "table": {
-                  "name": "postgres_qualified_enum_types"
-                },
-                "type": {
-                  "schema": "public",
                   "name": "c_enum"
                 }
               }
@@ -35108,7 +35101,7 @@
       }
     },
     {
-      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum\n)",
+      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum,\n    $9::c_enum\n)",
       "name": "InsertPostgresSpecialTypes",
       "cmd": ":exec",
       "parameters": [
@@ -35210,6 +35203,16 @@
               "name": "c_enum"
             }
           }
+        },
+        {
+          "number": 9,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
         }
       ],
       "comments": [
@@ -35269,7 +35272,7 @@
       "filename": "query.sql"
     },
     {
-      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\nFROM postgres_special_types \nLIMIT 1",
+      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\nFROM postgres_special_types \nLIMIT 1",
       "name": "GetPostgresSpecialTypes",
       "cmd": ":one",
       "columns": [
@@ -35362,6 +35365,18 @@
             "name": "c_enum"
           },
           "originalName": "c_enum"
+        },
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_special_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
         }
       ],
       "filename": "query.sql"
@@ -36245,53 +36260,6 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
-      "cmd": ":exec",
-      "filename": "query.sql"
-    },
-    {
-      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
-      "name": "InsertPostgresQualifiedEnumTypes",
-      "cmd": ":exec",
-      "parameters": [
-        {
-          "number": 1,
-          "column": {
-            "name": "c_qualified_enum",
-            "length": -1,
-            "type": {
-              "name": "c_enum"
-            }
-          }
-        }
-      ],
-      "filename": "query.sql",
-      "insert_into_table": {
-        "name": "postgres_qualified_enum_types"
-      }
-    },
-    {
-      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
-      "name": "GetPostgresQualifiedEnumTypes",
-      "cmd": ":one",
-      "columns": [
-        {
-          "name": "c_qualified_enum",
-          "length": -1,
-          "table": {
-            "name": "postgres_qualified_enum_types"
-          },
-          "type": {
-            "schema": "public",
-            "name": "c_enum"
-          },
-          "originalName": "c_qualified_enum"
-        }
-      ],
-      "filename": "query.sql"
-    },
-    {
-      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
-      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlExample/request.json
+++ b/examples/NpgsqlExample/request.json
@@ -686,6 +686,24 @@
                 }
               }
             ]
+          },
+          {
+            "rel": {
+              "name": "postgres_qualified_enum_types"
+            },
+            "columns": [
+              {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_qualified_enum_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              }
+            ]
           }
         ],
         "enums": [
@@ -36227,6 +36245,53 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
+      "cmd": ":exec",
+      "filename": "query.sql"
+    },
+    {
+      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
+      "name": "InsertPostgresQualifiedEnumTypes",
+      "cmd": ":exec",
+      "parameters": [
+        {
+          "number": 1,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
+        }
+      ],
+      "filename": "query.sql",
+      "insert_into_table": {
+        "name": "postgres_qualified_enum_types"
+      }
+    },
+    {
+      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
+      "name": "GetPostgresQualifiedEnumTypes",
+      "cmd": ":one",
+      "columns": [
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_qualified_enum_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
+        }
+      ],
+      "filename": "query.sql"
+    },
+    {
+      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
+      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlExample/request.message
+++ b/examples/NpgsqlExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlbü
 examples/NpgsqlExamplecsharpÃ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"net8.0","useDapper":false}*
-./dist/LocalRunner¡îpublic"ãpublicƒ
+./dist/LocalRunner–ïpublic"Øpublicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -98,7 +98,9 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
+postgres_qualified_enum_typesP
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10917,4 +10919,18 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*µ{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
+\INSERT INTO postgres_qualified_enum_types
+(
+    c_qualified_enum
+)
+VALUES (
+    $1::c_enum
+) InsertPostgresQualifiedEnumTypes:exec*+'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
+FSELECT
+    c_qualified_enum
+FROM postgres_qualified_enum_types
+LIMIT 1GetPostgresQualifiedEnumTypes:one"b
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
+,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*µ{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/NpgsqlExample/request.message
+++ b/examples/NpgsqlExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlbü
 examples/NpgsqlExamplecsharpÃ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"net8.0","useDapper":false}*
-./dist/LocalRunner–ïpublic"Øpublicƒ
+./dist/LocalRunnerìîpublic"®publicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -83,10 +83,11 @@ pg_catalog	timestampˆµ
 c_box0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbbox7
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpath=
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygon;
-c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircle’
+c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircleÝ
 postgres_special_types5
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuid7
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumA
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumI
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumA
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 pg_catalogjsonQ
 c_json_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -98,9 +99,7 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
-postgres_qualified_enum_typesP
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10682,8 +10681,8 @@ LIMIT 1GetPostgresNetworkTypesCnt:one"=
 ) VALUES ($1, $2, $3)InsertPostgresNetworkTypesBatch	:copyfrom*IE
 c_cidr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbcidrzc_cidr*IE
 c_inet0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbinetzc_inet*RN
-	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types¿
-—
+	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types’
+½
 INSERT INTO postgres_special_types
 (
     c_json,
@@ -10693,7 +10692,8 @@ INSERT INTO postgres_special_types
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 )
 VALUES (
     $1, 
@@ -10703,7 +10703,8 @@ VALUES (
     $5::xml,
     $6::xml,
     $7,
-    $8::c_enum
+    $8::c_enum,
+    $9::c_enum
 )InsertPostgresSpecialTypes:exec*VR
 c_json0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbpg_catalog.jsonzc_json*;7
 c_json_string_override0ÿÿÿÿÿÿÿÿÿb
@@ -10715,7 +10716,8 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿb
 c_xml0ÿÿÿÿÿÿÿÿÿbxml*-)
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿbxml*KG
 c_uuid0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbuuidzc_uuid*!
-c_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
+c_enum0ÿÿÿÿÿÿÿÿÿbc_enum*+	'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
 UINSERT INTO postgres_not_null_types
 (
     c_enum_not_null
@@ -10729,8 +10731,8 @@ VALUES (
 FROM postgres_not_null_types 
 LIMIT 1GetPostgresNotNullTypes:one"T
 c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enumzc_enum_not_null:	query.sqlX
-&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sqlµ
-­SELECT
+&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sql¨
+ÃSELECT
     c_json,
     c_json_string_override,
     c_jsonb,
@@ -10738,7 +10740,8 @@ LIMIT 1GetPostgresNotNullTypes:one"T
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 FROM postgres_special_types 
 LIMIT 1GetPostgresSpecialTypes:one"I
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -10753,7 +10756,8 @@ c_jsonpath":
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml"Z
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml_string_override"=
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuidzc_uuid"?
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum:	query.sqlW
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum"[
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumzc_qualified_enum:	query.sqlW
 %TRUNCATE TABLE postgres_special_typesTruncatePostgresSpecialTypes:exec:	query.sql®
 lINSERT INTO postgres_special_types
 (
@@ -10919,18 +10923,4 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
-\INSERT INTO postgres_qualified_enum_types
-(
-    c_qualified_enum
-)
-VALUES (
-    $1::c_enum
-) InsertPostgresQualifiedEnumTypes:exec*+'
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
-FSELECT
-    c_qualified_enum
-FROM postgres_qualified_enum_types
-LIMIT 1GetPostgresQualifiedEnumTypes:one"b
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
-,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*µ{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*µ{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"net8.0","namespaceName":"NpgsqlExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/NpgsqlLegacyExample/Models.cs
+++ b/examples/NpgsqlLegacyExample/Models.cs
@@ -97,6 +97,10 @@ namespace NpgsqlLegacyExampleGen
     {
         public CEnum CEnumNotNull { get; set; }
     };
+    public class PostgresQualifiedEnumType
+    {
+        public CEnum? CQualifiedEnum { get; set; }
+    };
     public class ExtendedBio
     {
         public string AuthorName { get; set; }

--- a/examples/NpgsqlLegacyExample/Models.cs
+++ b/examples/NpgsqlLegacyExample/Models.cs
@@ -86,6 +86,7 @@ namespace NpgsqlLegacyExampleGen
     {
         public Guid? CUuid { get; set; }
         public CEnum? CEnum { get; set; }
+        public CEnum? CQualifiedEnum { get; set; }
         public JsonElement? CJson { get; set; }
         public JsonElement? CJsonStringOverride { get; set; }
         public JsonElement? CJsonb { get; set; }
@@ -96,10 +97,6 @@ namespace NpgsqlLegacyExampleGen
     public class PostgresNotNullType
     {
         public CEnum CEnumNotNull { get; set; }
-    };
-    public class PostgresQualifiedEnumType
-    {
-        public CEnum? CQualifiedEnum { get; set; }
     };
     public class ExtendedBio
     {

--- a/examples/NpgsqlLegacyExample/QuerySql.cs
+++ b/examples/NpgsqlLegacyExample/QuerySql.cs
@@ -3016,5 +3016,124 @@ namespace NpgsqlLegacyExampleGen
                 await command.ExecuteNonQueryAsync();
             }
         }
+
+        private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
+                                                                     (
+                                                                         c_qualified_enum
+                                                                     )
+                                                                     VALUES (
+                                                                         @c_qualified_enum::c_enum
+                                                                     )";
+        public class InsertPostgresQualifiedEnumTypesArgs
+        {
+            public CEnum? CQualifiedEnum { get; set; }
+        };
+        public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
+        {
+            if (this.Transaction == null)
+            {
+                using (var connection = await GetDataSource().OpenConnectionAsync())
+                {
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = InsertPostgresQualifiedEnumTypesSql;
+                        command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
+                        await command.ExecuteNonQueryAsync();
+                    }
+
+                    return;
+                }
+            }
+
+            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+            using (var command = this.Transaction.Connection.CreateCommand())
+            {
+                command.CommandText = InsertPostgresQualifiedEnumTypesSql;
+                command.Transaction = this.Transaction;
+                command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
+                await command.ExecuteNonQueryAsync();
+            }
+        }
+
+        private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
+                                                                      c_qualified_enum
+                                                                  FROM postgres_qualified_enum_types
+                                                                  LIMIT 1";
+        public class GetPostgresQualifiedEnumTypesRow
+        {
+            public CEnum? CQualifiedEnum { get; set; }
+        };
+        public async Task<GetPostgresQualifiedEnumTypesRow> GetPostgresQualifiedEnumTypesAsync()
+        {
+            if (this.Transaction == null)
+            {
+                using (var connection = await GetDataSource().OpenConnectionAsync())
+                {
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = GetPostgresQualifiedEnumTypesSql;
+                        using (var reader = await command.ExecuteReaderAsync())
+                        {
+                            if (await reader.ReadAsync())
+                            {
+                                return new GetPostgresQualifiedEnumTypesRow
+                                {
+                                    CQualifiedEnum = reader.IsDBNull(0) ? (CEnum? )null : reader.GetString(0).ToCEnum()
+                                };
+                            }
+                        }
+                    }
+                };
+                return null;
+            }
+
+            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+            using (var command = this.Transaction.Connection.CreateCommand())
+            {
+                command.CommandText = GetPostgresQualifiedEnumTypesSql;
+                command.Transaction = this.Transaction;
+                using (var reader = await command.ExecuteReaderAsync())
+                {
+                    if (await reader.ReadAsync())
+                    {
+                        return new GetPostgresQualifiedEnumTypesRow
+                        {
+                            CQualifiedEnum = reader.IsDBNull(0) ? (CEnum? )null : reader.GetString(0).ToCEnum()
+                        };
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
+        public async Task TruncatePostgresQualifiedEnumTypesAsync()
+        {
+            if (this.Transaction == null)
+            {
+                using (var connection = await GetDataSource().OpenConnectionAsync())
+                {
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
+                        await command.ExecuteNonQueryAsync();
+                    }
+
+                    return;
+                }
+            }
+
+            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
+                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
+            using (var command = this.Transaction.Connection.CreateCommand())
+            {
+                command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
+                command.Transaction = this.Transaction;
+                await command.ExecuteNonQueryAsync();
+            }
+        }
     }
 }

--- a/examples/NpgsqlLegacyExample/QuerySql.cs
+++ b/examples/NpgsqlLegacyExample/QuerySql.cs
@@ -2148,7 +2148,8 @@ namespace NpgsqlLegacyExampleGen
                                                                    c_xml,
                                                                    c_xml_string_override,
                                                                    c_uuid,
-                                                                   c_enum
+                                                                   c_enum,
+                                                                   c_qualified_enum
                                                                )
                                                                VALUES (
                                                                    @c_json, 
@@ -2158,7 +2159,8 @@ namespace NpgsqlLegacyExampleGen
                                                                    @c_xml::xml,
                                                                    @c_xml_string_override::xml,
                                                                    @c_uuid,
-                                                                   @c_enum::c_enum
+                                                                   @c_enum::c_enum,
+                                                                   @c_qualified_enum::c_enum
                                                                )";
         public class InsertPostgresSpecialTypesArgs
         {
@@ -2170,6 +2172,7 @@ namespace NpgsqlLegacyExampleGen
             public string CXmlStringOverride { get; set; }
             public Guid? CUuid { get; set; }
             public CEnum? CEnum { get; set; }
+            public CEnum? CQualifiedEnum { get; set; }
         };
         public async Task InsertPostgresSpecialTypesAsync(InsertPostgresSpecialTypesArgs args)
         {
@@ -2188,6 +2191,7 @@ namespace NpgsqlLegacyExampleGen
                         command.Parameters.AddWithValue("@c_xml_string_override", NpgsqlDbType.Xml, args.CXmlStringOverride ?? (object)DBNull.Value);
                         command.Parameters.AddWithValue("@c_uuid", args.CUuid ?? (object)DBNull.Value);
                         command.Parameters.AddWithValue("@c_enum", args.CEnum != null ? args.CEnum.Value.Stringify() : (object)DBNull.Value);
+                        command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
                         await command.ExecuteNonQueryAsync();
                     }
 
@@ -2209,6 +2213,7 @@ namespace NpgsqlLegacyExampleGen
                 command.Parameters.AddWithValue("@c_xml_string_override", NpgsqlDbType.Xml, args.CXmlStringOverride ?? (object)DBNull.Value);
                 command.Parameters.AddWithValue("@c_uuid", args.CUuid ?? (object)DBNull.Value);
                 command.Parameters.AddWithValue("@c_enum", args.CEnum != null ? args.CEnum.Value.Stringify() : (object)DBNull.Value);
+                command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
                 await command.ExecuteNonQueryAsync();
             }
         }
@@ -2340,7 +2345,8 @@ namespace NpgsqlLegacyExampleGen
                                                                 c_xml,
                                                                 c_xml_string_override,
                                                                 c_uuid,
-                                                                c_enum
+                                                                c_enum,
+                                                                c_qualified_enum
                                                             FROM postgres_special_types 
                                                             LIMIT 1";
         public class GetPostgresSpecialTypesRow
@@ -2353,6 +2359,7 @@ namespace NpgsqlLegacyExampleGen
             public string CXmlStringOverride { get; set; }
             public Guid? CUuid { get; set; }
             public CEnum? CEnum { get; set; }
+            public CEnum? CQualifiedEnum { get; set; }
         };
         public async Task<GetPostgresSpecialTypesRow> GetPostgresSpecialTypesAsync()
         {
@@ -2381,7 +2388,8 @@ namespace NpgsqlLegacyExampleGen
                                     }))(reader, 4),
                                     CXmlStringOverride = reader.IsDBNull(5) ? null : reader.GetString(5),
                                     CUuid = reader.IsDBNull(6) ? (Guid? )null : reader.GetFieldValue<Guid>(6),
-                                    CEnum = reader.IsDBNull(7) ? (CEnum? )null : reader.GetString(7).ToCEnum()
+                                    CEnum = reader.IsDBNull(7) ? (CEnum? )null : reader.GetString(7).ToCEnum(),
+                                    CQualifiedEnum = reader.IsDBNull(8) ? (CEnum? )null : reader.GetString(8).ToCEnum()
                                 };
                             }
                         }
@@ -2414,7 +2422,8 @@ namespace NpgsqlLegacyExampleGen
                             }))(reader, 4),
                             CXmlStringOverride = reader.IsDBNull(5) ? null : reader.GetString(5),
                             CUuid = reader.IsDBNull(6) ? (Guid? )null : reader.GetFieldValue<Guid>(6),
-                            CEnum = reader.IsDBNull(7) ? (CEnum? )null : reader.GetString(7).ToCEnum()
+                            CEnum = reader.IsDBNull(7) ? (CEnum? )null : reader.GetString(7).ToCEnum(),
+                            CQualifiedEnum = reader.IsDBNull(8) ? (CEnum? )null : reader.GetString(8).ToCEnum()
                         };
                     }
                 }
@@ -3012,125 +3021,6 @@ namespace NpgsqlLegacyExampleGen
             using (var command = this.Transaction.Connection.CreateCommand())
             {
                 command.CommandText = TruncatePostgresGeoTypesSql;
-                command.Transaction = this.Transaction;
-                await command.ExecuteNonQueryAsync();
-            }
-        }
-
-        private const string InsertPostgresQualifiedEnumTypesSql = @"INSERT INTO postgres_qualified_enum_types
-                                                                     (
-                                                                         c_qualified_enum
-                                                                     )
-                                                                     VALUES (
-                                                                         @c_qualified_enum::c_enum
-                                                                     )";
-        public class InsertPostgresQualifiedEnumTypesArgs
-        {
-            public CEnum? CQualifiedEnum { get; set; }
-        };
-        public async Task InsertPostgresQualifiedEnumTypesAsync(InsertPostgresQualifiedEnumTypesArgs args)
-        {
-            if (this.Transaction == null)
-            {
-                using (var connection = await GetDataSource().OpenConnectionAsync())
-                {
-                    using (var command = connection.CreateCommand())
-                    {
-                        command.CommandText = InsertPostgresQualifiedEnumTypesSql;
-                        command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
-                        await command.ExecuteNonQueryAsync();
-                    }
-
-                    return;
-                }
-            }
-
-            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-            using (var command = this.Transaction.Connection.CreateCommand())
-            {
-                command.CommandText = InsertPostgresQualifiedEnumTypesSql;
-                command.Transaction = this.Transaction;
-                command.Parameters.AddWithValue("@c_qualified_enum", args.CQualifiedEnum != null ? args.CQualifiedEnum.Value.Stringify() : (object)DBNull.Value);
-                await command.ExecuteNonQueryAsync();
-            }
-        }
-
-        private const string GetPostgresQualifiedEnumTypesSql = @"SELECT
-                                                                      c_qualified_enum
-                                                                  FROM postgres_qualified_enum_types
-                                                                  LIMIT 1";
-        public class GetPostgresQualifiedEnumTypesRow
-        {
-            public CEnum? CQualifiedEnum { get; set; }
-        };
-        public async Task<GetPostgresQualifiedEnumTypesRow> GetPostgresQualifiedEnumTypesAsync()
-        {
-            if (this.Transaction == null)
-            {
-                using (var connection = await GetDataSource().OpenConnectionAsync())
-                {
-                    using (var command = connection.CreateCommand())
-                    {
-                        command.CommandText = GetPostgresQualifiedEnumTypesSql;
-                        using (var reader = await command.ExecuteReaderAsync())
-                        {
-                            if (await reader.ReadAsync())
-                            {
-                                return new GetPostgresQualifiedEnumTypesRow
-                                {
-                                    CQualifiedEnum = reader.IsDBNull(0) ? (CEnum? )null : reader.GetString(0).ToCEnum()
-                                };
-                            }
-                        }
-                    }
-                };
-                return null;
-            }
-
-            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-            using (var command = this.Transaction.Connection.CreateCommand())
-            {
-                command.CommandText = GetPostgresQualifiedEnumTypesSql;
-                command.Transaction = this.Transaction;
-                using (var reader = await command.ExecuteReaderAsync())
-                {
-                    if (await reader.ReadAsync())
-                    {
-                        return new GetPostgresQualifiedEnumTypesRow
-                        {
-                            CQualifiedEnum = reader.IsDBNull(0) ? (CEnum? )null : reader.GetString(0).ToCEnum()
-                        };
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private const string TruncatePostgresQualifiedEnumTypesSql = "TRUNCATE TABLE postgres_qualified_enum_types";
-        public async Task TruncatePostgresQualifiedEnumTypesAsync()
-        {
-            if (this.Transaction == null)
-            {
-                using (var connection = await GetDataSource().OpenConnectionAsync())
-                {
-                    using (var command = connection.CreateCommand())
-                    {
-                        command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
-                        await command.ExecuteNonQueryAsync();
-                    }
-
-                    return;
-                }
-            }
-
-            if (this.Transaction?.Connection == null || this.Transaction?.Connection.State != ConnectionState.Open)
-                throw new InvalidOperationException("Transaction is provided, but its connection is null.");
-            using (var command = this.Transaction.Connection.CreateCommand())
-            {
-                command.CommandText = TruncatePostgresQualifiedEnumTypesSql;
                 command.Transaction = this.Transaction;
                 await command.ExecuteNonQueryAsync();
             }

--- a/examples/NpgsqlLegacyExample/request.json
+++ b/examples/NpgsqlLegacyExample/request.json
@@ -606,6 +606,17 @@
                 }
               },
               {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_special_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              },
+              {
                 "name": "c_json",
                 "length": -1,
                 "table": {
@@ -682,24 +693,6 @@
                   "name": "postgres_not_null_types"
                 },
                 "type": {
-                  "name": "c_enum"
-                }
-              }
-            ]
-          },
-          {
-            "rel": {
-              "name": "postgres_qualified_enum_types"
-            },
-            "columns": [
-              {
-                "name": "c_qualified_enum",
-                "length": -1,
-                "table": {
-                  "name": "postgres_qualified_enum_types"
-                },
-                "type": {
-                  "schema": "public",
                   "name": "c_enum"
                 }
               }
@@ -35108,7 +35101,7 @@
       }
     },
     {
-      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum\n)",
+      "text": "\nINSERT INTO postgres_special_types\n(\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\n)\nVALUES (\n    $1, \n    $2::json, \n    $3,\n    $4::jsonpath,\n    $5::xml,\n    $6::xml,\n    $7,\n    $8::c_enum,\n    $9::c_enum\n)",
       "name": "InsertPostgresSpecialTypes",
       "cmd": ":exec",
       "parameters": [
@@ -35210,6 +35203,16 @@
               "name": "c_enum"
             }
           }
+        },
+        {
+          "number": 9,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
         }
       ],
       "comments": [
@@ -35269,7 +35272,7 @@
       "filename": "query.sql"
     },
     {
-      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum\nFROM postgres_special_types \nLIMIT 1",
+      "text": "SELECT\n    c_json,\n    c_json_string_override,\n    c_jsonb,\n    c_jsonpath,\n    c_xml,\n    c_xml_string_override,\n    c_uuid,\n    c_enum,\n    c_qualified_enum\nFROM postgres_special_types \nLIMIT 1",
       "name": "GetPostgresSpecialTypes",
       "cmd": ":one",
       "columns": [
@@ -35362,6 +35365,18 @@
             "name": "c_enum"
           },
           "originalName": "c_enum"
+        },
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_special_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
         }
       ],
       "filename": "query.sql"
@@ -36245,53 +36260,6 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
-      "cmd": ":exec",
-      "filename": "query.sql"
-    },
-    {
-      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
-      "name": "InsertPostgresQualifiedEnumTypes",
-      "cmd": ":exec",
-      "parameters": [
-        {
-          "number": 1,
-          "column": {
-            "name": "c_qualified_enum",
-            "length": -1,
-            "type": {
-              "name": "c_enum"
-            }
-          }
-        }
-      ],
-      "filename": "query.sql",
-      "insert_into_table": {
-        "name": "postgres_qualified_enum_types"
-      }
-    },
-    {
-      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
-      "name": "GetPostgresQualifiedEnumTypes",
-      "cmd": ":one",
-      "columns": [
-        {
-          "name": "c_qualified_enum",
-          "length": -1,
-          "table": {
-            "name": "postgres_qualified_enum_types"
-          },
-          "type": {
-            "schema": "public",
-            "name": "c_enum"
-          },
-          "originalName": "c_qualified_enum"
-        }
-      ],
-      "filename": "query.sql"
-    },
-    {
-      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
-      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlLegacyExample/request.json
+++ b/examples/NpgsqlLegacyExample/request.json
@@ -686,6 +686,24 @@
                 }
               }
             ]
+          },
+          {
+            "rel": {
+              "name": "postgres_qualified_enum_types"
+            },
+            "columns": [
+              {
+                "name": "c_qualified_enum",
+                "length": -1,
+                "table": {
+                  "name": "postgres_qualified_enum_types"
+                },
+                "type": {
+                  "schema": "public",
+                  "name": "c_enum"
+                }
+              }
+            ]
           }
         ],
         "enums": [
@@ -36227,6 +36245,53 @@
     {
       "text": "TRUNCATE TABLE postgres_geometric_types",
       "name": "TruncatePostgresGeoTypes",
+      "cmd": ":exec",
+      "filename": "query.sql"
+    },
+    {
+      "text": "INSERT INTO postgres_qualified_enum_types\n(\n    c_qualified_enum\n)\nVALUES (\n    $1::c_enum\n)",
+      "name": "InsertPostgresQualifiedEnumTypes",
+      "cmd": ":exec",
+      "parameters": [
+        {
+          "number": 1,
+          "column": {
+            "name": "c_qualified_enum",
+            "length": -1,
+            "type": {
+              "name": "c_enum"
+            }
+          }
+        }
+      ],
+      "filename": "query.sql",
+      "insert_into_table": {
+        "name": "postgres_qualified_enum_types"
+      }
+    },
+    {
+      "text": "SELECT\n    c_qualified_enum\nFROM postgres_qualified_enum_types\nLIMIT 1",
+      "name": "GetPostgresQualifiedEnumTypes",
+      "cmd": ":one",
+      "columns": [
+        {
+          "name": "c_qualified_enum",
+          "length": -1,
+          "table": {
+            "name": "postgres_qualified_enum_types"
+          },
+          "type": {
+            "schema": "public",
+            "name": "c_enum"
+          },
+          "originalName": "c_qualified_enum"
+        }
+      ],
+      "filename": "query.sql"
+    },
+    {
+      "text": "TRUNCATE TABLE postgres_qualified_enum_types",
+      "name": "TruncatePostgresQualifiedEnumTypes",
       "cmd": ":exec",
       "filename": "query.sql"
     }

--- a/examples/NpgsqlLegacyExample/request.message
+++ b/examples/NpgsqlLegacyExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlb
 examples/NpgsqlLegacyExamplecsharpÑ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlLegacyExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"netstandard2.0","useDapper":false}*
-./dist/LocalRunner–ïpublic"Øpublicƒ
+./dist/LocalRunnerìîpublic"®publicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -83,10 +83,11 @@ pg_catalog	timestampˆµ
 c_box0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbbox7
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpath=
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygon;
-c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircle’
+c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcircleİ
 postgres_special_types5
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuid7
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumA
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumI
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumA
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 pg_catalogjsonQ
 c_json_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -98,9 +99,7 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
-postgres_qualified_enum_typesP
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10682,8 +10681,8 @@ LIMIT 1GetPostgresNetworkTypesCnt:one"=
 ) VALUES ($1, $2, $3)InsertPostgresNetworkTypesBatch	:copyfrom*IE
 c_cidr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbcidrzc_cidr*IE
 c_inet0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesbinetzc_inet*RN
-	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types¿
-—
+	c_macaddr0ÿÿÿÿÿÿÿÿÿR publicpostgres_network_typesb	macaddrz	c_macaddr:	query.sqlBpostgres_network_types’
+½
 INSERT INTO postgres_special_types
 (
     c_json,
@@ -10693,7 +10692,8 @@ INSERT INTO postgres_special_types
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 )
 VALUES (
     $1, 
@@ -10703,7 +10703,8 @@ VALUES (
     $5::xml,
     $6::xml,
     $7,
-    $8::c_enum
+    $8::c_enum,
+    $9::c_enum
 )InsertPostgresSpecialTypes:exec*VR
 c_json0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbpg_catalog.jsonzc_json*;7
 c_json_string_override0ÿÿÿÿÿÿÿÿÿb
@@ -10715,7 +10716,8 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿb
 c_xml0ÿÿÿÿÿÿÿÿÿbxml*-)
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿbxml*KG
 c_uuid0ÿÿÿÿÿÿÿÿÿ8R publicpostgres_special_typesbuuidzc_uuid*!
-c_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
+c_enum0ÿÿÿÿÿÿÿÿÿbc_enum*+	'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum2 Special types :	query.sqlBpostgres_special_typesÎ
 UINSERT INTO postgres_not_null_types
 (
     c_enum_not_null
@@ -10729,8 +10731,8 @@ VALUES (
 FROM postgres_not_null_types 
 LIMIT 1GetPostgresNotNullTypes:one"T
 c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enumzc_enum_not_null:	query.sqlX
-&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sqlµ
-­SELECT
+&TRUNCATE TABLE postgres_not_null_typesTruncatePostgresNotNullTypes:exec:	query.sql¨
+ÃSELECT
     c_json,
     c_json_string_override,
     c_jsonb,
@@ -10738,7 +10740,8 @@ LIMIT 1GetPostgresNotNullTypes:one"T
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 FROM postgres_special_types 
 LIMIT 1GetPostgresSpecialTypes:one"I
 c_json0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
@@ -10753,7 +10756,8 @@ c_jsonpath":
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml"Z
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlzc_xml_string_override"=
 c_uuid0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbuuidzc_uuid"?
-c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum:	query.sqlW
+c_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbc_enumzc_enum"[
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbpublicc_enumzc_qualified_enum:	query.sqlW
 %TRUNCATE TABLE postgres_special_typesTruncatePostgresSpecialTypes:exec:	query.sql®
 lINSERT INTO postgres_special_types
 (
@@ -10919,18 +10923,4 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
-\INSERT INTO postgres_qualified_enum_types
-(
-    c_qualified_enum
-)
-VALUES (
-    $1::c_enum
-) InsertPostgresQualifiedEnumTypes:exec*+'
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
-FSELECT
-    c_qualified_enum
-FROM postgres_qualified_enum_types
-LIMIT 1GetPostgresQualifiedEnumTypes:one"b
-c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
-,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*Ã{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlLegacyExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*Ã{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlLegacyExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/NpgsqlLegacyExample/request.message
+++ b/examples/NpgsqlLegacyExample/request.message
@@ -3,7 +3,7 @@
 2
 postgresql-examples/config/postgresql/authors/schema.sql+examples/config/postgresql/types/schema.sql",examples/config/postgresql/authors/query.sql"*examples/config/postgresql/types/query.sqlb
 examples/NpgsqlLegacyExamplecsharpÑ{"debugRequest":true,"generateCsproj":true,"namespaceName":"NpgsqlLegacyExampleGen","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"notNull":false,"type":"int"}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"notNull":false,"type":"string"}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"notNull":true,"type":"DateTime"}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"notNull":false,"type":"JsonElement"}},{"column":"*:c_json_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_xml_string_override","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_macaddr8","csharp_type":{"notNull":false,"type":"string"}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"notNull":false,"type":"Instant"}}],"targetFramework":"netstandard2.0","useDapper":false}*
-./dist/LocalRunner¡îpublic"ãpublicƒ
+./dist/LocalRunner–ïpublic"Øpublicƒ
 	authors)
 id0ÿÿÿÿÿÿÿÿÿR	authorsb	bigserial&
 name0ÿÿÿÿÿÿÿÿÿR	authorsbtext#
@@ -98,7 +98,9 @@ c_jsonpath0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesb
 c_xml0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxmlC
 c_xml_string_override0ÿÿÿÿÿÿÿÿÿRpostgres_special_typesbxml`
 postgres_not_null_typesC
-c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enum"
+c_enum_not_null0ÿÿÿÿÿÿÿÿÿRpostgres_not_null_typesbc_enums
+postgres_qualified_enum_typesP
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enum"
 c_enumsmallmediumbig"	pg_temp"æ²
 pg_catalog‰
 &
@@ -10917,4 +10919,18 @@ hSELECT c_point, c_line, c_lseg, c_box, c_path, c_polygon, c_circle FROM postgre
 c_path0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbpathzc_path"H
 	c_polygon0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesb	polygonz	c_polygon"E
 c_circle0ÿÿÿÿÿÿÿÿÿRpostgres_geometric_typesbcirclezc_circle:	query.sqlU
-'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sql"v1.30.0*Ã{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlLegacyExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}
+'TRUNCATE TABLE postgres_geometric_typesTruncatePostgresGeoTypes:exec:	query.sqlà
+\INSERT INTO postgres_qualified_enum_types
+(
+    c_qualified_enum
+)
+VALUES (
+    $1::c_enum
+) InsertPostgresQualifiedEnumTypes:exec*+'
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿbc_enum:	query.sqlBpostgres_qualified_enum_typesÜ
+FSELECT
+    c_qualified_enum
+FROM postgres_qualified_enum_types
+LIMIT 1GetPostgresQualifiedEnumTypes:one"b
+c_qualified_enum0ÿÿÿÿÿÿÿÿÿRpostgres_qualified_enum_typesbpublicc_enumzc_qualified_enum:	query.sqld
+,TRUNCATE TABLE postgres_qualified_enum_types"TruncatePostgresQualifiedEnumTypes:exec:	query.sql"v1.30.0*Ã{"overrideDriverVersion":"","generateCsproj":true,"targetFramework":"netstandard2.0","namespaceName":"NpgsqlLegacyExampleGen","useDapper":false,"overrideDapperVersion":"","overrides":[{"column":"GetPostgresFunctions:max_integer","csharp_type":{"type":"int","notNull":false}},{"column":"GetPostgresFunctions:max_varchar","csharp_type":{"type":"string","notNull":false}},{"column":"GetPostgresFunctions:max_timestamp","csharp_type":{"type":"DateTime","notNull":true}},{"column":"GetPostgresSpecialTypesCnt:c_json","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"GetPostgresSpecialTypesCnt:c_jsonb","csharp_type":{"type":"JsonElement","notNull":false}},{"column":"*:c_json_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_xml_string_override","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_macaddr8","csharp_type":{"type":"string","notNull":false}},{"column":"*:c_timestamp_noda_instant_override","csharp_type":{"type":"Instant","notNull":false}}],"debugRequest":false,"useCentralPackageManagement":false,"withAsyncSuffix":true}

--- a/examples/config/postgresql/types/query.sql
+++ b/examples/config/postgresql/types/query.sql
@@ -241,7 +241,8 @@ INSERT INTO postgres_special_types
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 )
 VALUES (
     sqlc.narg('c_json'), 
@@ -251,7 +252,8 @@ VALUES (
     sqlc.narg('c_xml')::xml,
     sqlc.narg('c_xml_string_override')::xml,
     sqlc.narg('c_uuid'),
-    sqlc.narg('c_enum')::c_enum
+    sqlc.narg('c_enum')::c_enum,
+    sqlc.narg('c_qualified_enum')::c_enum
 );
 
 -- name: InsertPostgresNotNullTypes :exec
@@ -281,7 +283,8 @@ SELECT
     c_xml,
     c_xml_string_override,
     c_uuid,
-    c_enum
+    c_enum,
+    c_qualified_enum
 FROM postgres_special_types 
 LIMIT 1;
 
@@ -413,20 +416,3 @@ SELECT * FROM postgres_geometric_types LIMIT 1;
 -- name: TruncatePostgresGeoTypes :exec
 TRUNCATE TABLE postgres_geometric_types;
 
--- name: InsertPostgresQualifiedEnumTypes :exec
-INSERT INTO postgres_qualified_enum_types
-(
-    c_qualified_enum
-)
-VALUES (
-    sqlc.narg('c_qualified_enum')::c_enum
-);
-
--- name: GetPostgresQualifiedEnumTypes :one
-SELECT
-    c_qualified_enum
-FROM postgres_qualified_enum_types
-LIMIT 1;
-
--- name: TruncatePostgresQualifiedEnumTypes :exec
-TRUNCATE TABLE postgres_qualified_enum_types;

--- a/examples/config/postgresql/types/query.sql
+++ b/examples/config/postgresql/types/query.sql
@@ -412,3 +412,21 @@ SELECT * FROM postgres_geometric_types LIMIT 1;
 
 -- name: TruncatePostgresGeoTypes :exec
 TRUNCATE TABLE postgres_geometric_types;
+
+-- name: InsertPostgresQualifiedEnumTypes :exec
+INSERT INTO postgres_qualified_enum_types
+(
+    c_qualified_enum
+)
+VALUES (
+    sqlc.narg('c_qualified_enum')::c_enum
+);
+
+-- name: GetPostgresQualifiedEnumTypes :one
+SELECT
+    c_qualified_enum
+FROM postgres_qualified_enum_types
+LIMIT 1;
+
+-- name: TruncatePostgresQualifiedEnumTypes :exec
+TRUNCATE TABLE postgres_qualified_enum_types;

--- a/examples/config/postgresql/types/schema.sql
+++ b/examples/config/postgresql/types/schema.sql
@@ -67,6 +67,7 @@ CREATE TYPE c_enum AS ENUM ('small', 'medium', 'big');
 CREATE TABLE postgres_special_types (
     c_uuid                 UUID,
     c_enum                 c_enum,
+    c_qualified_enum       public.c_enum,
     c_json                 JSON,
     c_json_string_override JSON,
     c_jsonb                JSONB,
@@ -77,8 +78,4 @@ CREATE TABLE postgres_special_types (
 
 CREATE TABLE postgres_not_null_types (
     c_enum_not_null        c_enum NOT NULL DEFAULT 'small'
-);
-
-CREATE TABLE postgres_qualified_enum_types (
-    c_qualified_enum       public.c_enum
 );

--- a/examples/config/postgresql/types/schema.sql
+++ b/examples/config/postgresql/types/schema.sql
@@ -78,3 +78,7 @@ CREATE TABLE postgres_special_types (
 CREATE TABLE postgres_not_null_types (
     c_enum_not_null        c_enum NOT NULL DEFAULT 'small'
 );
+
+CREATE TABLE postgres_qualified_enum_types (
+    c_qualified_enum       public.c_enum
+);

--- a/unit-tests/CodegenTests/CodegenSchemaTests.cs
+++ b/unit-tests/CodegenTests/CodegenSchemaTests.cs
@@ -1,6 +1,9 @@
+using Google.Protobuf;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Framework;
+using Plugin;
 using SqlcGenCsharp;
+using System.Text;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace CodegenTests;
@@ -53,6 +56,63 @@ public class CodegenSchemaTests
         };
         var actual = GetMemberNames(modelsCode);
         Assert.That(actual.IsSupersetOf(expected));
+    }
+
+    [Test]
+    public void TestDefaultSchemaEnumWithSchemaQualifiedType()
+    {
+        var request = new GenerateRequest
+        {
+            Settings = new Settings
+            {
+                Engine = "postgresql",
+                Codegen = new Codegen { Out = "DummyProject" }
+            },
+            Catalog = new Catalog
+            {
+                DefaultSchema = "public",
+                Schemas =
+                {
+                    new Schema
+                    {
+                        Name = "public",
+                        Enums =
+                        {
+                            new Plugin.Enum
+                            {
+                                Name = "post_block_type",
+                                Vals = { "text", "markdown", "media" }
+                            }
+                        },
+                        Tables =
+                        {
+                            new Table
+                            {
+                                Rel = new Identifier { Name = "post_block" },
+                                Columns =
+                                {
+                                    new Column
+                                    {
+                                        Name = "block_type",
+                                        Type = new Identifier
+                                        {
+                                            Name = "post_block_type",
+                                            Schema = "public"
+                                        },
+                                        NotNull = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            PluginOptions = ByteString.CopyFrom("{}", Encoding.UTF8)
+        };
+
+        var response = CodeGenerator.Generate(request);
+        var generatedModelsFile = response.Result.Files.First(f => f.Name == "Models.cs");
+        Assert.That(generatedModelsFile, Is.Not.Null);
     }
 
     private static HashSet<string> GetMemberNames(CompilationUnitSyntax compilationUnit)

--- a/unit-tests/CodegenTests/CodegenSchemaTests.cs
+++ b/unit-tests/CodegenTests/CodegenSchemaTests.cs
@@ -111,8 +111,7 @@ public class CodegenSchemaTests
         };
 
         var response = CodeGenerator.Generate(request);
-        var generatedModelsFile = response.Result.Files.First(f => f.Name == "Models.cs");
-        Assert.That(generatedModelsFile, Is.Not.Null);
+        Assert.That(response.Result.Files.Any(f => f.Name == "Models.cs"), Is.True);
     }
 
     private static HashSet<string> GetMemberNames(CompilationUnitSyntax compilationUnit)


### PR DESCRIPTION
Fixes #399

When a PostgreSQL column references an enum type with schema qualification (e.g., `block_type public.post_block_type`), sqlc sets `column.Type.Schema` to `"public"`. However, `ConstructEnumsLookup` normalizes default schema enums under key `""` (empty string), causing `GetEnumType` to fail the lookup and throw `NotSupportedException`.

## Changes

1. **`Drivers/NpgsqlDriver.cs`** — Normalize the schema name in `GetEnumSchemaAndName` to empty string when it matches `DefaultSchema`, making it consistent with `ConstructEnumsLookup`.

2. **`unit-tests/CodegenTests/CodegenSchemaTests.cs`** — Added `TestDefaultSchemaEnumWithSchemaQualifiedType` that constructs a `GenerateRequest` with `column.Type.Schema = "public"` and asserts successful generation (was throwing before the fix).

3. **`examples/config/postgresql/types/`** — Added `postgres_qualified_enum_types` table with a column referencing `public.c_enum` (schema-qualified), plus INSERT/SELECT/TRUNCATE queries. This exercises the fixed code path in e2e tests.

4. **`examples/Npgsql*`** — Regenerated all Npgsql example code to include the new model/queries.

5. **`end2end/`** — Added `TruncatePostgresQualifiedEnumTypesAsync` to both Npgsql and NpgsqlDapper tester TearDown methods.

## Testing

- All 20 unit tests pass
- The new unit test reproduces the exact stack trace from the issue before the fix
- The new table `postgres_qualified_enum_types` with `public.c_enum` column verifies the fix end-to-end