### PR TITLE
refactor: simplify release flow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,14 @@
 name: Docs
+
+concurrency: docs-regeneration
+
 defaults:
   run:
     shell: bash
     
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   DOTNET_VERSION: '8.0.x'
@@ -30,10 +34,14 @@ jobs:
       - name: Regenerate docs
         run: ./docs/scripts/generate_all_docs.sh
 
-      - name: Commit changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --quiet || git commit -m "docs: regenerate documentation"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          base: main
+          title: update auto-generated docs
+          commit-message: update docs
+          branch: update-docs
+          branch-suffix: timestamp
+          delete-branch: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,18 +5,15 @@ defaults:
     
 permissions:
   contents: write
-  pull-requests: write
 
 env:
   DOTNET_VERSION: '8.0.x'
 
 on:
-  release:
-    types: [ published ]
   workflow_dispatch:
     
 jobs:
-  generate-and-push-docs:
+  generate-docs:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,17 +27,13 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           
-      - name: Updating docs
+      - name: Regenerate docs
         run: ./docs/scripts/generate_all_docs.sh
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          base: main
-          title: update auto-generated docs
-          commit-message: update docs
-          branch: update-docs
-          branch-suffix: timestamp
-          delete-branch: true
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --quiet || git commit -m "docs: regenerate documentation"
+          git push

--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Check if this is a release commit
         id: check-release
@@ -79,13 +80,13 @@ jobs:
 
               LABELED_PR_LIST="$LABELED_PR_LIST #$PR_NUM"
 
-              if echo "$LABELS" | grep -q "major"; then
+              if echo "$LABELS" | grep -qx "major"; then
                 MAJOR_COUNT=$((MAJOR_COUNT + 1))
                 MAJOR_PRS="$MAJOR_PRS\n- $PR_TITLE (#$PR_NUM)"
-              elif echo "$LABELS" | grep -q "minor"; then
+              elif echo "$LABELS" | grep -qx "minor"; then
                 MINOR_COUNT=$((MINOR_COUNT + 1))
                 MINOR_PRS="$MINOR_PRS\n- $PR_TITLE (#$PR_NUM)"
-              elif echo "$LABELS" | grep -q "patch"; then
+              elif echo "$LABELS" | grep -qx "patch"; then
                 PATCH_COUNT=$((PATCH_COUNT + 1))
                 PATCH_PRS="$PATCH_PRS\n- $PR_TITLE (#$PR_NUM)"
               fi

--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           COMMIT_MSG=$(git log -1 --pretty=%B)
           echo "Commit message: $COMMIT_MSG"
-          if echo "$COMMIT_MSG" | grep -q "chore: prepare release v"; then
+          if echo "$COMMIT_MSG" | grep -q "Release Prep v"; then
             echo "This is a release commit, skipping workflow"
             echo "is-release=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -1,0 +1,188 @@
+name: Generate Release PR
+
+concurrency: release-prep-${{ github.ref_name }}
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        description: Override release type
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  accumulate-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Check if this is a release commit
+        id: check-release
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          echo "Commit message: $COMMIT_MSG"
+          if echo "$COMMIT_MSG" | grep -q "chore: prepare release v"; then
+            echo "This is a release commit, skipping workflow"
+            echo "is-release=true" >> $GITHUB_OUTPUT
+          else
+            echo "Not a release commit, continuing workflow"
+            echo "is-release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get all unreleased merged PRs and determine version
+        if: steps.check-release.outputs.is-release == 'false'
+        id: unreleased
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+
+          LATEST_TAG=$(gh api repos/$OWNER/$REPO/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
+          echo "LATEST_TAG: $LATEST_TAG"
+
+          if [ -z "$LATEST_TAG" ]; then
+            COMMITS=$(git log --oneline --grep="Merge pull request" --grep="#[0-9]" -E)
+          else
+            COMMITS=$(git log ${LATEST_TAG}..HEAD --oneline --grep="Merge pull request" --grep="#[0-9]" -E)
+          fi
+
+          PATCH_COUNT=0
+          MINOR_COUNT=0
+          MAJOR_COUNT=0
+          LABELED_PR_LIST=""
+          MAJOR_PRS=""
+          MINOR_PRS=""
+          PATCH_PRS=""
+
+          while IFS= read -r commit; do
+            PR_NUM=$(echo "$commit" | grep -oE '#[0-9]+' | tr -d '#' || echo "")
+            if [ -n "$PR_NUM" ]; then
+              LABELS=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUM --jq '.labels[].name' 2>/dev/null || echo "")
+              PR_TITLE=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUM --jq '.title' 2>/dev/null || echo "PR #$PR_NUM")
+
+              LABELED_PR_LIST="$LABELED_PR_LIST #$PR_NUM"
+
+              if echo "$LABELS" | grep -q "major"; then
+                MAJOR_COUNT=$((MAJOR_COUNT + 1))
+                MAJOR_PRS="$MAJOR_PRS\n- $PR_TITLE (#$PR_NUM)"
+              elif echo "$LABELS" | grep -q "minor"; then
+                MINOR_COUNT=$((MINOR_COUNT + 1))
+                MINOR_PRS="$MINOR_PRS\n- $PR_TITLE (#$PR_NUM)"
+              elif echo "$LABELS" | grep -q "patch"; then
+                PATCH_COUNT=$((PATCH_COUNT + 1))
+                PATCH_PRS="$PATCH_PRS\n- $PR_TITLE (#$PR_NUM)"
+              fi
+            fi
+          done <<< "$COMMITS"
+
+          if [ "$MAJOR_COUNT" -gt 0 ]; then
+            RELEASE_TYPE="major"
+          elif [ "$MINOR_COUNT" -gt 0 ]; then
+            RELEASE_TYPE="minor"
+          elif [ "$PATCH_COUNT" -gt 0 ]; then
+            RELEASE_TYPE="patch"
+          else
+            RELEASE_TYPE="none"
+          fi
+
+          if [ "${{ github.event.inputs.release-type }}" != "" ] && [ "${{ github.event.inputs.release-type }}" != "auto" ]; then
+            RELEASE_TYPE="${{ github.event.inputs.release-type }}"
+            echo "Release type overridden by workflow dispatch: $RELEASE_TYPE"
+          fi
+
+          echo "Final release type: $RELEASE_TYPE"
+          echo "release-type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+          echo "labeled-pr-list=$LABELED_PR_LIST" >> $GITHUB_OUTPUT
+
+      - name: Compute new version
+        if: steps.unreleased.outputs.release-type != 'none' && steps.unreleased.outputs.release-type != ''
+        id: version-update
+        run: |
+          CURRENT_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "v0.0.0")
+          echo "Current version: $CURRENT_VERSION"
+
+          BASE_VERSION=$(echo "$CURRENT_VERSION" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")
+          echo "Base version: $BASE_VERSION"
+
+          IFS='.' read -r major minor patch <<< "$BASE_VERSION"
+
+          RELEASE_TYPE="${{ steps.unreleased.outputs.release-type }}"
+          echo "Release type: $RELEASE_TYPE"
+
+          if [ "$RELEASE_TYPE" = "major" ]; then
+            NEW_BASE_VERSION="$((major+1)).0.0"
+          elif [ "$RELEASE_TYPE" = "minor" ]; then
+            NEW_BASE_VERSION="$major.$((minor+1)).0"
+          else
+            NEW_BASE_VERSION="$major.$minor.$((patch+1))"
+          fi
+
+          NEW_VERSION="v${NEW_BASE_VERSION}"
+          echo "New version: $NEW_VERSION"
+          echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Download wasm artifact for sha computation
+        if: steps.version-update.outputs.new-version != ''
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: main
+          name: wasm-file
+
+      - name: Compute sha and regenerate docs
+        if: steps.version-update.outputs.new-version != ''
+        id: doc-gen
+        env:
+          PLUGIN_VERSION: ${{ steps.version-update.outputs.new-version }}
+        run: |
+          SHA256_HASH=$(sha256sum plugin.wasm | awk '{ print $1 }')
+          echo "Computed sha256: $SHA256_HASH"
+          echo "plugin-sha=$SHA256_HASH" >> $GITHUB_OUTPUT
+
+          export PLUGIN_VERSION="${{ steps.version-update.outputs.new-version }}"
+          export PLUGIN_SHA="$SHA256_HASH"
+          ./docs/scripts/generate_all_docs.sh
+
+          echo "Re-generated documentation"
+          git status
+
+      - name: Create release PR
+        if: steps.version-update.outputs.new-version != ''
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: prepare release ${{ steps.version-update.outputs.new-version }}"
+          title: "Release Prep ${{ steps.version-update.outputs.new-version }}"
+          body: |
+            ## Automated Release Prep
+
+            **Release Type:** ${{ steps.unreleased.outputs.release-type }}
+            **New Version:** ${{ steps.version-update.outputs.new-version }}
+
+            This PR was created automatically. It updates documentation with the release version and sha.
+
+            When merged, the Release workflow will create the GitHub release with the accumulated release notes.
+          branch: release-prep
+          base: ${{ github.ref_name }}
+          labels: |
+            release
+            automated

--- a/.github/workflows/release-assistant.yml
+++ b/.github/workflows/release-assistant.yml
@@ -39,7 +39,6 @@ jobs:
             "LocalRunner/"
             "\.csproj"
             "global\.json"
-            "Directory\.Build\.props"
             "sqlc\.ci\.yaml"
           )
 
@@ -61,10 +60,15 @@ jobs:
           if echo "$LABELS_JSON" | grep -q "skip-release"; then
             SKIP_RELEASE_LABEL=true
           fi
-          VERSION_LABEL_VALUE=$(echo "$LABELS_JSON" | grep -E "(major|minor|patch)" | head -1 | tr -d '[:space:]')
+          VERSION_LABEL_VALUE=$(echo "$LABELS_JSON" | grep -E "^(major|minor|patch)$" | head -1 | tr -d '[:space:]')
           if [ -n "$VERSION_LABEL_VALUE" ]; then
             HAS_VERSION_LABEL=true
             VERSION_LABEL="$VERSION_LABEL_VALUE"
+          fi
+          VERSION_LABEL_COUNT=$(echo "$LABELS_JSON" | grep -cE "^(major|minor|patch)$" || true)
+          MULTIPLE_VERSION_LABELS=false
+          if [ "$VERSION_LABEL_COUNT" -gt 1 ]; then
+            MULTIPLE_VERSION_LABELS=true
           fi
 
           echo "version-worthy=$VERSION_WORTHY" >> $GITHUB_OUTPUT
@@ -72,6 +76,7 @@ jobs:
           echo "has-version-label=$HAS_VERSION_LABEL" >> $GITHUB_OUTPUT
           echo "version-label=$VERSION_LABEL" >> $GITHUB_OUTPUT
           echo "matched-patterns=$MATCHED_PATTERNS" >> $GITHUB_OUTPUT
+          echo "multiple-version-labels=$MULTIPLE_VERSION_LABELS" >> $GITHUB_OUTPUT
 
       - name: Update PR comment
         uses: actions/github-script@v7
@@ -82,6 +87,7 @@ jobs:
             const skipReleaseLabel = '${{ steps.analysis.outputs.skip-release-label }}' === 'true';
             const versionLabel = '${{ steps.analysis.outputs.version-label }}';
             const matchedPatterns = '${{ steps.analysis.outputs.matched-patterns }}';
+            const multipleVersionLabels = '${{ steps.analysis.outputs.multiple-version-labels }}' === 'true';
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -119,6 +125,13 @@ jobs:
                 '',
                 'This PR cannot be merged until a version label is added.',
               ].join('\n');
+            } else if (multipleVersionLabels) {
+              body = [
+                '<!-- release-assistant-bot -->',
+                '## Release Assistant - Action Required',
+                '',
+                'Multiple version labels detected. Please keep only one of: `major`, `minor`, `patch`.',
+              ].join('\n');
             } else {
               body = [
                 '<!-- release-assistant-bot -->',
@@ -154,6 +167,7 @@ jobs:
             const versionWorthy = '${{ steps.analysis.outputs.version-worthy }}' === 'true';
             const hasVersionLabel = '${{ steps.analysis.outputs.has-version-label }}' === 'true';
             const skipReleaseLabel = '${{ steps.analysis.outputs.skip-release-label }}' === 'true';
+            const multipleVersionLabels = '${{ steps.analysis.outputs.multiple-version-labels }}' === 'true';
 
             let state, description;
 
@@ -166,6 +180,9 @@ jobs:
             } else if (!hasVersionLabel) {
               state = 'failure';
               description = 'Version label (major/minor/patch) required';
+            } else if (multipleVersionLabels) {
+              state = 'failure';
+              description = 'Multiple version labels found. Keep only one';
             } else {
               state = 'success';
               description = 'All release requirements satisfied';

--- a/.github/workflows/release-assistant.yml
+++ b/.github/workflows/release-assistant.yml
@@ -1,0 +1,199 @@
+name: Release Assistant
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.head_ref != 'release-prep')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Analyze PR changes
+        id: analysis
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          CHANGED_FILES=$(gh pr view ${{ env.PR_NUMBER }} --json files --jq '.files[].path' | tr '\n' ' ')
+          echo "Changed files: $CHANGED_FILES"
+
+          VERSION_WORTHY_PATTERNS=(
+            "SqlcGenCsharp/"
+            "CodeGenerator/"
+            "Drivers/"
+            "Extensions/"
+            "PluginOptions/"
+            "WasmRunner/"
+            "LocalRunner/"
+            "\.csproj"
+            "global\.json"
+            "Directory\.Build\.props"
+            "sqlc\.ci\.yaml"
+          )
+
+          VERSION_WORTHY=false
+          MATCHED_PATTERNS=""
+
+          for pattern in "${VERSION_WORTHY_PATTERNS[@]}"; do
+            if echo "$CHANGED_FILES" | grep -q "$pattern"; then
+              VERSION_WORTHY=true
+              MATCHED_PATTERNS="$MATCHED_PATTERNS $pattern"
+            fi
+          done
+
+          LABELS_JSON=$(gh pr view ${{ env.PR_NUMBER }} --json labels --jq '.labels[].name')
+          HAS_VERSION_LABEL=false
+          VERSION_LABEL=""
+          SKIP_RELEASE_LABEL=false
+
+          if echo "$LABELS_JSON" | grep -q "skip-release"; then
+            SKIP_RELEASE_LABEL=true
+          fi
+          VERSION_LABEL_VALUE=$(echo "$LABELS_JSON" | grep -E "(major|minor|patch)" | head -1 | tr -d '[:space:]')
+          if [ -n "$VERSION_LABEL_VALUE" ]; then
+            HAS_VERSION_LABEL=true
+            VERSION_LABEL="$VERSION_LABEL_VALUE"
+          fi
+
+          echo "version-worthy=$VERSION_WORTHY" >> $GITHUB_OUTPUT
+          echo "skip-release-label=$SKIP_RELEASE_LABEL" >> $GITHUB_OUTPUT
+          echo "has-version-label=$HAS_VERSION_LABEL" >> $GITHUB_OUTPUT
+          echo "version-label=$VERSION_LABEL" >> $GITHUB_OUTPUT
+          echo "matched-patterns=$MATCHED_PATTERNS" >> $GITHUB_OUTPUT
+
+      - name: Update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const versionWorthy = '${{ steps.analysis.outputs.version-worthy }}' === 'true';
+            const hasVersionLabel = '${{ steps.analysis.outputs.has-version-label }}' === 'true';
+            const skipReleaseLabel = '${{ steps.analysis.outputs.skip-release-label }}' === 'true';
+            const versionLabel = '${{ steps.analysis.outputs.version-label }}';
+            const matchedPatterns = '${{ steps.analysis.outputs.matched-patterns }}';
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            let body;
+
+            if (skipReleaseLabel) {
+              body = [
+                '<!-- release-assistant-bot -->',
+                '## Release Assistant - Passed',
+                '',
+                'PR marked as `skip-release`. No release will be triggered.',
+              ].join('\n');
+            } else if (!versionWorthy) {
+              body = [
+                '<!-- release-assistant-bot -->',
+                '## Release Assistant - Passed',
+                '',
+                'No version-worthy changes detected. Only non-functional, doc, or test changes.',
+              ].join('\n');
+            } else if (!hasVersionLabel) {
+              const patterns = matchedPatterns.split(' ').filter(p => p.trim()).map(p => `- \`${p.trim()}\``).join('\n');
+              body = [
+                '<!-- release-assistant-bot -->',
+                '## Release Assistant - Action Required',
+                '',
+                'Version-worthy changes detected in:',
+                patterns,
+                '',
+                'Add one of the following labels to this PR: `major`, `minor`, `patch`.',
+                '',
+                '- `patch` — Bug fixes, documentation updates',
+                '- `minor` — New features, backwards-compatible',
+                '- `major` — Breaking changes, API modifications',
+                '',
+                'This PR cannot be merged until a version label is added.',
+              ].join('\n');
+            } else {
+              body = [
+                '<!-- release-assistant-bot -->',
+                '## Release Assistant - Passed',
+                '',
+                'All requirements satisfied.',
+                '',
+                '**Release Information:**',
+                `- Type: \`${versionLabel}\``,
+                '',
+                'This PR is ready to merge.',
+              ].join('\n');
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: context.issue.number
+            });
+            const botComment = comments.find(c => c.body && c.body.includes('<!-- release-assistant-bot -->'));
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: botComment.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: context.issue.number, body
+              });
+            }
+
+      - name: Set commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const versionWorthy = '${{ steps.analysis.outputs.version-worthy }}' === 'true';
+            const hasVersionLabel = '${{ steps.analysis.outputs.has-version-label }}' === 'true';
+            const skipReleaseLabel = '${{ steps.analysis.outputs.skip-release-label }}' === 'true';
+
+            let state, description;
+
+            if (skipReleaseLabel) {
+              state = 'success';
+              description = 'Skipped by skip-release label';
+            } else if (!versionWorthy) {
+              state = 'success';
+              description = 'No version-worthy changes';
+            } else if (!hasVersionLabel) {
+              state = 'failure';
+              description = 'Version label (major/minor/patch) required';
+            } else {
+              state = 'success';
+              description = 'All release requirements satisfied';
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: state,
+              target_url: `${context.payload.repository.html_url}/actions/runs/${context.runId}`,
+              description: description,
+              context: 'release-assistant/requirements'
+            });
+
+  release-prep-bypass:
+    if: github.event_name == 'pull_request' && github.head_ref == 'release-prep'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set passing status for release-prep
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'success',
+              context: 'release-assistant/requirements',
+              description: 'Bypassed for release-prep PR'
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,18 @@
 name: Release
-defaults:
-  run:
-    shell: bash
-
-permissions:
-  contents: write
-  pull-requests: write
 
 on:
-  workflow_run: 
+  workflow_run:
     workflows: [Build]
     types: [completed]
     branches: [main]
+
+permissions:
+  contents: write
+  releases: write
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   check_commit:
@@ -20,102 +21,71 @@ jobs:
     outputs:
       IS_RELEASE: ${{ steps.check_msg.outputs.IS_RELEASE }}
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Check latest commit message
         id: check_msg
         run: |
-          LATEST_COMMIT_MSG=$(git log -1 --pretty=%B | cat)
-          if [[ ${LATEST_COMMIT_MSG} == *"[release]"* ]]; then
-            echo "release message found - continuing with the release"
-            IS_RELEASE="true"
+          LATEST_COMMIT_MSG=$(git log -1 --pretty=%B)
+          if echo "$LATEST_COMMIT_MSG" | grep -q "chore: prepare release v"; then
+            echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
           else
-            echo "no release message found - skipping..."
-            IS_RELEASE="false"
+            echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
           fi
-          echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
-          
+
   release:
     name: Release
     needs: [check_commit]
-    runs-on: ubuntu-latest
     if: ${{ needs.check_commit.outputs.IS_RELEASE == 'true' }}
-    env:
-      IS_RELEASE: ${{  needs.check_commit.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
+
       - name: Download artifact
-        id: download-artifact
         uses: dawidd6/action-download-artifact@v6
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build.yml
           workflow_conclusion: success
           name: wasm-file
-          
-      - name: Bump version
-        run: |
-          set -e
-          LATEST_COMMIT_MSG=$(git log -1 --pretty=%B | cat)
-          
-          echo "Extract the latest tag version"
-          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
-          
-          BUMP_TYPE="patch" # Initialize the default version bump type to patch
-          if [[ "${LATEST_COMMIT_MSG}" == *"[major]"* ]]; then
-            BUMP_TYPE="major"
-          elif [[ "${LATEST_COMMIT_MSG}" == *"[minor]"* ]]; then
-            BUMP_TYPE="minor"
-          fi
 
-          case ${BUMP_TYPE} in
-            "major")
-              NEW_TAG=$(echo "${LATEST_TAG}" | awk -F. '{OFS="."; $1="v" substr($1,2)+1; $2="0"; $3="0"; print}')
-              ;;
-            "minor")
-              NEW_TAG=$(echo "${LATEST_TAG}" | awk -F. '{OFS="."; $2=$2+1; $3="0"; print}')
-              ;;
-            "patch")
-              NEW_TAG=$(echo "${LATEST_TAG}" | awk -F. '{OFS="."; $3=$3+1; print}')
-              ;;
-          esac
-          
-          echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
-          echo "NEW_TAG=${NEW_TAG}" >> $GITHUB_ENV
-
-      - name: Push tag
+      - name: Extract version from commit message
+        id: extract-version
         run: |
-          NEW_TAG=${{ env.NEW_TAG }}
-          
-          git tag ${NEW_TAG}
-          git push origin ${NEW_TAG}
-          
+          VERSION=$(git log -1 --pretty=%B | grep -oP 'chore: prepare release \Kv[0-9]+\.[0-9]+\.[0-9]+')
+          echo "Extracted version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Calculate sha256
         run: |
           SHA256_HASH=$(sha256sum plugin.wasm | awk '{ print $1 }')
           echo "SHA256_HASH=${SHA256_HASH}" >> $GITHUB_ENV
-          echo "The calculated sha256 is $SHA256_HASH"
 
-      - name: Create release draft
+      - name: Reconstruct release notes from PRs
+        id: notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -e
-          
-          LATEST_TAG=${{ env.LATEST_TAG }}
-          NEW_TAG=${{ env.NEW_TAG }}
-          SHA256_HASH=${{ env.SHA256_HASH }}
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          VERSION=${{ steps.extract-version.outputs.version }}
 
-          CHANGE_LOG=$(git --no-pager log ${LATEST_TAG}..HEAD --pretty=format:'%h - %an, %ar : %s')
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | head -2 | tail -1)
 
-          # Define the release notes template
-          RELEASE_NOTES=$(cat <<EOF
-          ## Release version ${NEW_TAG}
+          if [ -z "$PREVIOUS_TAG" ]; then
+            COMMITS=$(git log --oneline --grep="Merge pull request" --grep="#[0-9]" -E)
+          else
+            COMMITS=$(git log ${PREVIOUS_TAG}..HEAD --oneline --grep="Merge pull request" --grep="#[0-9]" -E)
+          fi
+
+          NOTES_FILE=$(mktemp)
+          echo "notes-file=$NOTES_FILE" >> $GITHUB_OUTPUT
+
+          cat > "$NOTES_FILE" <<- ENDOFNOTE
+          ## Release ${VERSION}
+
           Release sha256 is \`${SHA256_HASH}\`
 
           ## Configuration example
@@ -124,22 +94,36 @@ jobs:
           plugins:
           - name: csharp
             wasm:
-              url: https://github.com/DaredevilOSS/sqlc-gen-csharp/releases/download/${NEW_TAG}/sqlc-gen-csharp.wasm
+              url: https://github.com/${{ github.repository }}/releases/download/${VERSION}/sqlc-gen-csharp.wasm
               sha256: ${SHA256_HASH}
           \`\`\`
-          ## Changelog 
-          ${CHANGE_LOG}
 
-          ## Contributors
-          * @SockworkOrange
-          EOF
-          )
+          ## Changelog
+          ENDOFNOTE
 
-          # change file name to convention
+          while IFS= read -r commit; do
+            PR_NUM=$(echo "$commit" | grep -oE '#[0-9]+' | tr -d '#' || echo "")
+            if [ -n "$PR_NUM" ]; then
+              PR_TITLE=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUM --jq '.title' 2>/dev/null || echo "PR #$PR_NUM")
+              echo "- $PR_TITLE (#$PR_NUM)" >> "$NOTES_FILE"
+            fi
+          done <<< "$COMMITS"
+
+          echo "" >> "$NOTES_FILE"
+          echo "## Contributors" >> "$NOTES_FILE"
+          echo "* @SockworkOrange" >> "$NOTES_FILE"
+
+      - name: Create release and upload asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TAG=${{ steps.extract-version.outputs.version }}
           mv plugin.wasm sqlc-gen-csharp.wasm
 
-          # Create a draft release
-          gh release create ${NEW_TAG} sqlc-gen-csharp.wasm \
-          --draft \
-          --title "${NEW_TAG}" \
-          --notes "${RELEASE_NOTES}"
+          echo "Creating release ${NEW_TAG}..."
+          gh release create ${NEW_TAG} \
+            sqlc-gen-csharp.wasm \
+            --title "${NEW_TAG}" \
+            --notes-file "${{ steps.notes.outputs.notes-file }}"
+
+          echo "Release ${NEW_TAG} published successfully"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         id: check_msg
         run: |
           LATEST_COMMIT_MSG=$(git log -1 --pretty=%B)
-          if echo "$LATEST_COMMIT_MSG" | grep -q "chore: prepare release v"; then
+          if echo "$LATEST_COMMIT_MSG" | grep -q "Release Prep v"; then
             echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
           else
             echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
@@ -54,7 +54,7 @@ jobs:
       - name: Extract version from commit message
         id: extract-version
         run: |
-          VERSION=$(git log -1 --pretty=%B | grep -oP 'chore: prepare release \Kv[0-9]+\.[0-9]+\.[0-9]+')
+          VERSION=$(git log -1 --pretty=%B | grep -oP 'Release Prep \Kv[0-9]+\.[0-9]+\.[0-9]+')
           echo "Extracted version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -72,7 +72,7 @@ jobs:
           REPO="${{ github.event.repository.name }}"
           VERSION=${{ steps.extract-version.outputs.version }}
 
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | head -2 | tail -1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | head -1)
 
           if [ -z "$PREVIOUS_TAG" ]; then
             COMMITS=$(git log --oneline --grep="Merge pull request" --grep="#[0-9]" -E)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
       IS_RELEASE: ${{ steps.check_msg.outputs.IS_RELEASE }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Check latest commit message
         id: check_msg
@@ -42,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,281 @@
+# AGENTS.md - SQLC Gen C# Codebase Guide
+
+## 🎯 Project Overview
+
+**sqlc-gen-csharp** is a .NET plugin for [sqlc](https://github.com/sqlc-dev/sqlc) that generates type-safe C# data access code from SQL queries.
+
+**Key Purpose:** Generate C# classes (queries, models, utils) from SQL queries using database drivers (Npgsql, MySqlConnector, Microsoft.Data.Sqlite) or optionally Dapper.
+
+**Supported Databases:**
+- PostgreSQL (Npgsql driver)
+- MySQL (MySqlConnector driver)
+- SQLite (Microsoft.Data.Sqlite driver)
+
+---
+
+## 📁 Core Architecture
+
+### Main Entry Point
+| File | Purpose |
+|------|---------|
+| `SqlcGenCsharp/PluginRunner.cs` | Main plugin entry point - handles requests |
+| `CodeGenerator/CodeGenerator.cs` | Orchestrates code generation flow |
+
+### Generator Components
+| File | Purpose |
+|------|---------|
+| `CodeGenerator/Generators/QueriesGen.cs` | Generates query classes with CRUD methods |
+| `CodeGenerator/Generators/ModelsGen.cs` | Generates POCOs for database tables |
+| `CodeGenerator/Generators/UtilsGen.cs` | Generates utility classes |
+| `CodeGenerator/Generators/CsprojGen.cs` | Generates .csproj files |
+
+### Database Drivers
+| File | Purpose |
+|------|---------|
+| `Drivers/DbDriver.cs` | Abstract base driver class |
+| `Drivers/NpgsqlDriver.cs` | PostgreSQL driver implementation |
+| `Drivers/MySqlConnectorDriver.cs` | MySQL driver implementation |
+| `Drivers/SqliteDriver.cs` | SQLite driver implementation |
+| `Drivers/EnumDbDriver.cs` | Generates enum types |
+
+---
+
+## 🏗️ Code Generation Flow
+
+```
+1. Generate() method in CodeGenerator.cs
+   ↓
+2. InitGenerators() - Parse options, instantiate drivers
+   ↓
+3. InstantiateDriver() - Select driver based on DriverName
+   ↓
+4. GetFileQueries() - Group queries by table
+   ↓
+5. GenerateFiles() - Call appropriate generators
+   ↓
+6. Return GenerateResponse with generated files
+```
+
+### Driver Instantiation
+```csharp
+DbDriver InstantiateDriver()
+{
+    return Options.DriverName switch
+    {
+        DriverName.MySqlConnector => new MySqlConnectorDriver(...),
+        DriverName.Npgsql => new NpgsqlDriver(...),
+        DriverName.Sqlite => new SqliteDriver(...),
+        _ => throw new ArgumentException("unknown driver")
+    }
+}
+```
+
+---
+
+## 🗄️ Database-Specific Implementation Differences
+
+### PostgreSQL
+- **`:execlastid`**: Uses `RETURNING` clause
+- **`:copyfrom`**: Uses `COPY FROM` binary command
+- **Supported types**: Boolean, integer types, decimal, date/time, JSON/JSONB, arrays, enums, etc.
+
+### MySQL
+- **`:execlastid`** (Driver): Uses `MySqlConnector.LastInsertedId` property
+- **`:execlastid`** (Dapper): Appends `SELECT LAST_INSERT_ID()` to query
+- **`:copyfrom`**: Uses `LOAD DATA` from CSV file
+- **Supported types**: Boolean, integer types, decimal, date/time, JSON, geometry
+
+### SQLite
+- **`:execlastid`**: Uses `RETURNING` clause (integer only)
+- **`:copyfrom`**: Uses multi-VALUES clause
+- **Supported types**: Limited - integer, real, text, blob
+- **Override support**: Can override to DateTime, bool, etc.
+
+---
+
+## ⚙️ Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `overrideDriverVersion` | 2.3.6 (MySql), 8.0.3 (Npgsql), 8.0.10 (Sqlite) | Override DB driver version |
+| `targetFramework` | net8.0 | .NET Standard 2.0/2.1 or .NET 8.0 |
+| `generateCsproj` | true | Generate .csproj file |
+| `namespaceName` | Project name | Override generated namespace |
+| `useDapper` | false | Use Dapper wrapper |
+| `overrideDapperVersion` | 2.1.66 | Override Dapper version |
+| `useCentralPackageManagement` | false | Support central package management |
+| `withAsyncSuffix` | true | Append "Async" to method names |
+| `overrides` | - | Per-column type overrides |
+
+---
+
+## 🔧 Query Annotations Support
+
+| Annotation | PostgreSQL | MySQL | SQLite | Description |
+|------------|-----------|-------|--------|-------------|
+| `:one` | ✅ | ✅ | ✅ | Returns 0...1 records |
+| `:many` | ✅ | ✅ | ✅ | Returns 0...n records |
+| `:exec` | ✅ | ✅ | ✅ | DML/DDDL - no return |
+| `:execrows` | ✅ | ✅ | ✅ | Returns affected rows count |
+| `:execlastid` | ✅ | ✅ | ✅ | INSERT with returned ID |
+| `:copyfrom` | ✅ | ✅ | ✅ | Batch insert |
+
+### Macro Annotations
+| Macro | PostgreSQL | MySQL | SQLite | Description |
+|-------|-----------|-------|--------|-------------|
+| `sqlc.arg` | ✅ | ✅ | ✅ | Named parameters |
+| `sqlc.narg` | ✅ | ✅ | ✅ | Nullable named parameters |
+| `sqlc.slice` | 🚫 | ✅ | ✅ | Dynamic query for arrays |
+| `sqlc.embed` | ✅ | ✅ | ✅ | Embed existing models |
+
+---
+
+## 🎨 Code Generation Patterns
+
+### Query Class Structure
+```csharp
+public partial class AuthorsQueries
+{
+    private readonly string _connectionString;
+    private IDbConnection? _connection;
+    private IDbTransaction? _transaction;
+    
+    // Constructor with connection string
+    public AuthorsQueries(string connectionString) 
+    {
+        _connectionString = connectionString;
+    }
+    
+    // Query methods
+    public Task<Author?> GetAuthorAsync(int id) => ...
+    public Task<IEnumerable<Author>> GetAuthorsAsync() => ...
+    public Task<int> CreateAuthorAsync(CreateAuthorParams params) => ...
+}
+```
+
+### Model Structure
+```csharp
+public partial class Author
+{
+    public int AuthorID { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Bio { get; set; }
+}
+```
+
+### Type Mapping
+- **Column types** are mapped to C# types via `ColumnMappings`
+- **Overrides** can be applied per column: `overrideOption.Column == "GetAuthor:Name"`
+- **Nullable types** in .NET Core are inferred from `notNull` column attribute
+
+---
+
+## 🧪 Testing & Development
+
+### Local Development
+```bash
+# Prerequisites
+dotnet --version # .NET 8.0
+buf --version
+# WASM libs for .NET WASI (see WASM docs)
+
+# Generate protobuf
+make protobuf-generate
+
+# Generate code
+make sqlc-generate-process
+make sqlc-generate-wasm
+
+# Test plugins
+make test-process-plugin
+make test-wasm-plugin
+```
+
+### Pre-commit Setup
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+---
+
+## 📝 Common Patterns
+
+### Type Handler Registration (Dapper)
+```csharp
+public static void ConfigureSqlMapper()
+{
+    SqlMapper.TypeHandler<Instant>.Register(new NodaInstantTypeHandler());
+    // Other type handlers...
+}
+```
+
+### Parameter Binding
+```csharp
+command.Parameters.AddWithValue("@column_name", 
+    param.Value ?? (object)DBNull.Value);
+```
+
+### Slice Arguments (MySQL/SQLite)
+```csharp
+for (int i = 0; i < paramArray.Length; i++)
+    command.Parameters.AddWithValue($"@paramArg{i}", paramArray[i]);
+```
+
+---
+
+## 🐛 Known Issues & TODOs
+
+1. **2D arrays** in batch inserts work but may have edge cases
+2. **Time with time zone** not supported (PostgreSQL)
+3. **Array columns** override handling marked as TODO
+4. **Geometry types** (MySQL) marked with ⚠️ - partial support
+5. **macaddr8 conversion** requires explicit cast in INSERT
+
+---
+
+## 📚 Key Files to Know
+
+- **`CodeGenerator/CodeGenerator.cs`** - Main orchestration
+- **`Drivers/DbDriver.cs`** - Base driver with shared logic
+- **`Drivers/NpgsqlDriver.cs`** - Most complex driver (33KB)
+- **`Drivers/MySqlConnectorDriver.cs`** - MySQL-specific logic
+- **`Drivers/SqliteDriver.cs`** - Simplest driver
+- **`Extensions/*`** - Helper methods for code generation
+
+---
+
+## 🚀 Quick Reference
+
+### Generate Code
+```bash
+make sqlc-generate-process  # Process-based plugin
+make sqlc-generate-wasm     # WASM plugin
+```
+
+### Test
+```bash
+make test-process-plugin
+make test-wasm-plugin
+```
+
+### Release
+The release flow uses three automated workflows:
+
+1. **Release Assistant** (`release-assistant.yml`) - runs on every PR to `main`. Validates that version-worthy PRs have a `major`/`minor`/`patch` label. Sets `release-assistant/requirements` status check.
+
+2. **Generate Release PR** (`gen-release-pr.yml`) - triggered when Build completes on `main`. Aggregates all labeled, merged PRs since the last release, computes the new version, regenerates docs with the wasm sha, and opens a `release-prep` PR.
+
+3. **Release** (`release.yml`) - triggered when the `release-prep` PR is merged. Creates the release tag, reconstructs release notes from merged PR titles, and uploads the wasm asset.
+
+---
+
+## 📖 External References
+
+- [SQLC Documentation](https://docs.sqlc.dev/)
+- [Npgsql](https://www.npgsql.org/)
+- [MySqlConnector](https://mysqlconnector.net/)
+- [Dapper](https://github.com/DapperLib/Dapper)
+- [NodaTime](https://nodatime.org/)
+
+---

--- a/docs/08_Contributing.md
+++ b/docs/08_Contributing.md
@@ -38,14 +38,32 @@ make test-wasm-plugin
 ```
 
 ## Release flow
+
 The release flow in this repo follows the semver conventions, building tag as `v[major].[minor].[patch]`.
-In order to create a release you need to add `[release]` somewhere in your commit message when merging to master.
 
-### Version bumping (built on tags)
-By default, the release script will bump the patch version. Adding `[release]` to your commit message results in a new tag with `v[major].[minor].[patch]+1`. 
-- Bump `minor` version by adding `[minor]` to your commit message resulting in a new tag with `v[major].[minor]+1.0` <br/>
-- Bump `major` version by adding `[major]` to your commit message resulting in a new tag with `v[major]+1.0.0` <br/>
+### PR Gate
 
-### Release structure
-The new created tag will create a draft release with it, in the release there will be the wasm plugin embedded in the release. <br/>
+Every PR that modifies source code, build configuration, or similar must be labeled with one of: `major`, `minor`, `patch`, or `skip-release`.
+
+A bot posts a status check (`release-assistant/requirements`) that blocks merging until a version label is present.
+
+### Generate Release PR
+
+When Build completes on `main`, the `gen-release-pr.yml` workflow runs and:
+
+1. Aggregates all unreleased, labeled PRs since the last release tag.
+2. Determines the release type from the labels (`major` > `minor` > `patch`).
+3. Computes the new version from the latest tag.
+4. Downloads the latest wasm artifact and computes its sha256.
+5. Regenerates documentation (README, quickstart) with the new version and wasm sha.
+6. Opens a `release-prep` PR with the regenerated docs.
+
+### Release
+
+When the `release-prep` PR is merged, `release.yml`:
+
+1. Detects the `chore: prepare release vX` commit.
+2. Downloads the wasm artifact from the triggering Build.
+3. Reconstructs release notes from merged PR titles since the previous tag.
+4. Creates the release (with tag) and uploads the wasm asset.
 

--- a/docs/scripts/generate_quickstart.sh
+++ b/docs/scripts/generate_quickstart.sh
@@ -2,10 +2,15 @@
 
 set -e
 
-plugin_version=$(git tag | sort --version-sort | tail -n1)
-plugin_url="https://github.com/DaredevilOSS/sqlc-gen-csharp/releases/download/${plugin_version}/sqlc-gen-csharp.wasm"
-curl -sL --output /tmp/plugin.wasm "${plugin_url}"
-release_sha=$(shasum -a 256 /tmp/plugin.wasm | awk '{ print $1 }')
+if [ -n "$PLUGIN_VERSION" ] && [ -n "$PLUGIN_SHA" ]; then
+  plugin_version="$PLUGIN_VERSION"
+  release_sha="$PLUGIN_SHA"
+else
+  plugin_version=$(git tag | sort --version-sort | tail -n1)
+  plugin_url="https://github.com/DaredevilOSS/sqlc-gen-csharp/releases/download/${plugin_version}/sqlc-gen-csharp.wasm"
+  curl -sL --output /tmp/plugin.wasm "${plugin_url}"
+  release_sha=$(shasum -a 256 /tmp/plugin.wasm | awk '{ print $1 }')
+fi
     
 contents="## Quickstart
 \`\`\`yaml


### PR DESCRIPTION
## Summary

Replaces the keyword-in-commit-message release flow with a structured, PR-gated pipeline adapted from Java JetBrains extension workflows.

### What changed

**New workflows:**
- `release-assistant.yml` — PR gate that validates version-worthy PRs have a `major`/ `minor`/ `patch` label. Sets `release-assistant/requirements` commit status.
- `gen-release-pr.yml` — Triggered after Build completes. Aggregates labeled PRs, computes version and wasm sha, regenerates docs, opens/updates a `release-prep` PR.

**Rewritten workflows:**
- `release.yml` — Creates release from scratch (not draft edit). Reconstructs release notes from merged PR titles via gh API. Uploads wasm asset.
- `docs.yml` — Removed `release: published` trigger and auto-PR step. Manual dispatch only.

**Supporting changes:**
- `generate_quickstart.sh` — Accepts `PLUGIN_VERSION`/`PLUGIN_SHA` env vars for docs regeneration.
- `docs/08_Contributing.md` + `AGENTS.md` — Updated release flow documentation.

### What was removed
- `CHANGELOG.md` generation
- `.changes/*.md` file requirement and validation
- Draft GitHub release creation in gen-release-pr
- `release-gate` naming (replaced with `release-assistant`)

### How it works

```
Feature PR merges → Build → gen-release-pr.yml opens/updates release-prep PR
  (accumulates PRs, computes version+sha, regenerates docs)
User reviews and merges release-prep PR
  → Build → release.yml creates release (tag + wasm + notes from git)
```

The release-prep PR always reflects the latest state — it gets updated every time Build completes on main.