### PR TITLE
fix: use pull_request_target for release assistant to support fork PRs

### DIFF
--- a/.github/workflows/release-assistant.yml
+++ b/.github/workflows/release-assistant.yml
@@ -1,7 +1,7 @@
 name: Release Assistant
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, labeled, unlabeled, synchronize]
     branches: [main]
 
@@ -15,11 +15,8 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.head_ref != 'release-prep')
+      (github.event_name == 'pull_request_target' && github.event.pull_request.state == 'open' && github.head_ref != 'release-prep')
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Analyze PR changes
         id: analysis
         env:
@@ -199,7 +196,7 @@ jobs:
             });
 
   release-prep-bypass:
-    if: github.event_name == 'pull_request' && github.head_ref == 'release-prep'
+    if: github.event_name == 'pull_request_target' && github.head_ref == 'release-prep'
     runs-on: ubuntu-latest
     steps:
       - name: Set passing status for release-prep


### PR DESCRIPTION
The release-assistant workflow used `pull_request` which restricts `GITHUB_TOKEN` to read-only for fork PRs, causing a 403 when trying to post comments/set statuses.

Switched to `pull_request_target` — safe here since the workflow only reads PR metadata via the API (no PR code is ever executed). Also removed the unnecessary `actions/checkout` step.