### PR TITLE
fix: ensure WASM sha in docs matches released binary

### DIFF
--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -172,6 +172,13 @@ jobs:
           echo "Re-generated documentation"
           git status
 
+      - name: Upload wasm as release candidate
+        if: steps.version-update.outputs.new-version != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-${{ steps.version-update.outputs.new-version }}
+          path: plugin.wasm
+
       - name: Generate PR body
         if: steps.version-update.outputs.new-version != ''
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,20 +46,20 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: build.yml
-          workflow_conclusion: success
-          name: wasm-file
-
       - name: Extract version from commit message
         id: extract-version
         run: |
           VERSION=$(git log -1 --pretty=%B | grep -oP 'Release Prep \Kv[0-9]+\.[0-9]+\.[0-9]+')
           echo "Extracted version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Download wasm
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: gen-release-pr.yml
+          workflow_conclusion: success
+          name: wasm-${{ steps.extract-version.outputs.version }}
 
       - name: Calculate sha256
         run: |


### PR DESCRIPTION
## Problem

When a release-prep PR merges, `release.yml` downloads a **fresh** WASM artifact from the Build workflow (triggered by the merge commit). The SHA of that fresh binary rarely matches the SHA computed during `gen-release-pr.yml`, so the docs end up with a stale/incorrect SHA.

## Solution

Two changes:

### `gen-release-pr.yml`
After computing the SHA and regenerating docs, upload the WASM as a **versioned artifact** (`wasm-vX.Y.Z`).

### `release.yml`
1. **Extract version first** (moved before download)
2. **Download the versioned artifact** from `gen-release-pr.yml` instead of the latest `build.yml` run

This guarantees the exact same `plugin.wasm` binary is used for both doc SHA computation and release upload.

## Flow

1. Build runs on main → uploads `wasm-file`
2. `gen-release-pr.yml` triggers → downloads it, computes SHA, regenerates docs, **uploads `wasm-vX.Y.Z`**, creates release-prep PR
3. You merge the PR (squash & merge)
4. `release.yml` triggers → extracts version from commit message → downloads `wasm-vX.Y.Z` from step 2 → creates release with the **same binary** → SHA matches the docs