### PR TITLE
fix: remove invalid 'releases' permission in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  releases: write
 
 defaults:
   run:


### PR DESCRIPTION
The `releases` permission scope is not valid in GitHub Actions workflow permissions. Creating releases is covered by `contents: write`, which is already present.