### PR TITLE
fix: align commit message with release check pattern

### DIFF
--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -270,7 +270,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: prepare release ${{ steps.version-update.outputs.new-version }}"
+          commit-message: "Release Prep ${{ steps.version-update.outputs.new-version }}"
           title: "Release Prep ${{ steps.version-update.outputs.new-version }}"
           body-path: /tmp/pr-body.md
           branch: release-prep


### PR DESCRIPTION
The gen-release-pr workflow creates commits with message `chore: prepare release v...`, but both the skip check in gen-release-pr and the trigger check in release.yml look for `Release Prep v` in the commit message. This causes the release workflow to never trigger and the gen-release-pr to not skip itself.

Changed the commit message to `Release Prep v...` to match the PR title and the expected pattern.