### PR TITLE
fix: resolve release workflow wasm artifact lookup across runs

### DIFF
--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -150,9 +150,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: build.yml
-          workflow_conclusion: success
-          branch: main
+          run_id: ${{ github.event.workflow_run.id }}
           name: wasm-file
 
       - name: Compute sha and regenerate docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           ARTIFACT_NAME="wasm-${VERSION}"
-          RUN_ID=$(gh api "/repos/${{ github.repository }}/actions/artifacts" \
-            --paginate \
+          RUN_ID=$(gh api "/repos/${{ github.repository }}/actions/artifacts?per_page=100" \
             --jq "[.artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .workflow_run.id][0]")
 
           if [ -z "$RUN_ID" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 defaults:
   run:
@@ -45,20 +46,33 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Extract version from commit message
-        id: extract-version
+      - name: Extract version and find wasm artifact
+        id: find-artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(git log -1 --pretty=%B | grep -oP 'Release Prep \Kv[0-9]+\.[0-9]+\.[0-9]+')
-          echo "Extracted version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          ARTIFACT_NAME="wasm-${VERSION}"
+          RUN_ID=$(gh api "/repos/${{ github.repository }}/actions/artifacts" \
+            --paginate \
+            --jq "[.artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .workflow_run.id][0]")
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Error: Could not find artifact ${ARTIFACT_NAME} in any workflow run" >&2
+            exit 1
+          fi
+
+          echo "Found ${ARTIFACT_NAME} in workflow run: $RUN_ID"
+          echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Download wasm
         uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: gen-release-pr.yml
-          workflow_conclusion: success
-          name: wasm-${{ steps.extract-version.outputs.version }}
+          run_id: ${{ steps.find-artifact.outputs.run-id }}
+          name: wasm-${{ steps.find-artifact.outputs.version }}
 
       - name: Calculate sha256
         run: |
@@ -72,7 +86,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
         run: |
-          VERSION=${{ steps.extract-version.outputs.version }}
+          VERSION=${{ steps.find-artifact.outputs.version }}
           PREVIOUS_TAG=$(git tag --sort=-v:refname | head -1)
 
           NOTES_FILE=$(mktemp)
@@ -86,7 +100,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEW_TAG=${{ steps.extract-version.outputs.version }}
+          NEW_TAG=${{ steps.find-artifact.outputs.version }}
           mv plugin.wasm sqlc-gen-csharp.wasm
 
           echo "Creating release ${NEW_TAG}..."


### PR DESCRIPTION
## Problem

The release workflow (`release.yml`) failed to download the wasm artifact because it searched for `wasm-<version>` in the latest successful run of `gen-release-pr.yml`. After the release-prep PR merges, `gen-release-pr.yml` detects the release commit and skips all steps — including uploading the artifact.

If other PRs merge between the release-prep PR creation and its merge, `HEAD~1`-based approaches also break.

## Solution

Use the GitHub API (`gh api /repos/.../actions/artifacts`) to search **all artifacts across all workflow runs** for the uniquely-named `wasm-<version>` artifact, then download from the exact run that produced it. The artifact name includes the version, making it a unique identifier regardless of intervening runs.

Also pinned the wasm download in `gen-release-pr.yml` to the specific triggering Build run via `run_id` to avoid race conditions.

## Changes

- **release.yml**: Replace `dawidd6/action-download-artifact` with `workflow` filter + GitHub API search for the artifact by name across all runs. Add `actions: read` permission.
- **gen-release-pr.yml**: Pin wasm download to the triggering Build run via `run_id: ${{ github.event.workflow_run.id }}`.